### PR TITLE
V1.0.1

### DIFF
--- a/modules/dna_alignment/gatk_baserecalibration.jst
+++ b/modules/dna_alignment/gatk_baserecalibration.jst
@@ -161,8 +161,12 @@
     samtools index -@ 10 "{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/{{ sample.name }}.{{ aligner }}.bam"
 
 {% set task %}no_baserecalibration_{{ sample.name }}_{{ aligner }}{% endset %}
+{% set before_list = [] %}
 {% set before %}freebayes_sex_check_{{ sample.name }}_{{ aligner }}{% endset %}
+{% do before_list.append(before) %}
+{% set before %}samtools_process_freebayes_sex_check_{{ sample.name }}_{{ aligner }}{% endset %}
+{% do before_list.append(before) %}
 {% set directory %}temp/{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}{% endset %}
-{{- remove_files(directory,before,task) }}
+{{- remove_files(directory,before_list,task) }}
 
 {% endmacro %}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -3,8 +3,6 @@
 {% from 'modules/dna_alignment/bwa_mem2_samtools.jst' import bwa_mem2_samtools with context %}
 {% from 'modules/dna_alignment/pb_fq2bam.jst' import fq2bam with context %}
 {% from 'modules/dna_alignment/split_fastq.jst' import split_fastqs with context %}
-{% from 'utilities/bam_to_cram.jst' import bam_to_cram with context %}
-{% from 'utilities/read_group_line.jst' import read_group_line %}
 {% from 'modules/qc/main.jst' import bam_qc with context %}
 
 

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2,7 +2,7 @@ __pipeline__:
   name: tempe
   main: main.jst
   description: Rapid Human GRCh38 genomics suite
-  version: v1.0.0
+  version: development
 constants:
   tools:
     base:
@@ -97,8 +97,8 @@ constants:
       container: ghcr.io/tgen/jetstream_containers/vardict:1.7.9
       digest: 0f7e273e1c7f7f74c285b9d1e04fd484f5fc1fa767bb9a0b7a077ae5da21eabc
     vcfmerger:
-      container: ghcr.io/tgen/jetstream_containers/vcfmerger2:0.9.0
-      digest: 0bc446d0f44f399068889a9d3c96ee662037861def06906c8e655ce18947abeb
+      container: ghcr.io/tgen/jetstream_containers/vcfmerger2:0.9.1
+      digest: 9a2f75b32ef56b81ef0b7419f8214a7043c6f8f892d6e504b6d12cdc43f9dba9
     vep:
       container: ghcr.io/tgen/jetstream_containers/ensembl-vep:release_107.0
       digest: 2762c6efff95ecac45bcb1dfccdb7c139e2cc4700b855b68632dcdf45d9c7712

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2,7 +2,7 @@ __pipeline__:
   name: tempe
   main: main.jst
   description: Rapid Human GRCh38 genomics suite
-  version: development
+  version: v1.0.1
 constants:
   tools:
     base:

--- a/utilities/remove_files.jst
+++ b/utilities/remove_files.jst
@@ -12,7 +12,14 @@
 
 - name: removing_files_{{ task_name }}
   {% if before is not none %}
-  before-re: {{ before }}
+  before-re:
+    {% if before is string %}
+    - {{ before }}
+    {% else %}
+    {% for task in before %}
+    - {{ task }}
+    {% endfor %}
+    {% endif %}
   {% endif %}
   after-re:
     {% if after is string %}


### PR DESCRIPTION
Changes:
* Now using vcfmerger 0.9.1 to resolve bug in strelka prep
* Removing files macro update to have more intricate before directive logic, allows for placing before multiple tasks instead of just one
* Minor cleanup in dna_alignment main

This should only cause restarts for vcfmerger as the `before` directive is not part of the task identity.