### PR TITLE
v1.1.2

### DIFF
--- a/modules/constitutional/main.jst
+++ b/modules/constitutional/main.jst
@@ -51,35 +51,35 @@
         {% if tasks.Genome_constitutional_cna_caller_ichor|default(false) %}
            {{- ichorcna(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
-        {% if tasks[taskPrefix+"_constitutional_structural_caller_expansion_hunter"]|default(false) %}
-           {{- expansion_hunter(sample, aligner) }}
-        {% endif %}
     {% endif %}
 
     {%- if sample.subGroup|lower != 'tumor' %}
         {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_gatk_HaplotypeCaller"]|default(false) %}
             {{- haplotypecallergvcf(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_genotype_hc_gvcf_gatk_GenotypeGVCFs"]|default(false) %}
-            {{- genotypegvcf(sample, aligner, taskPrefix=taskPrefix) }}
+        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_deepvariant"]|default(false) %}
+            {{- deepvariant(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
         {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_freebayes"]|default(false) %}
             {{- freebayes(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_structural_caller_manta"]|default(false) %}
-            {{- manta_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+        {%- if tasks[taskPrefix+"_constitutional_genotype_hc_gvcf_gatk_GenotypeGVCFs"]|default(false) %}
+            {{- genotypegvcf(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
         {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_strelka2"]|default(false) %}
             {{- strelka2_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_deepvariant"]|default(false) %}
-            {{- deepvariant(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
         {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_octopus"]|default(false) %}
             {{- octopus_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
         {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_vardict"]|default(false) %}
             {{- vardict_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+        {% endif %}
+        {%- if tasks[taskPrefix+"_constitutional_structural_caller_manta"]|default(false) %}
+            {{- manta_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+        {% endif %}
+        {% if tasks[taskPrefix+"_constitutional_structural_caller_expansion_hunter"]|default(false) %}
+           {{- expansion_hunter(sample, aligner) }}
         {% endif %}
         {%- if tasks[taskPrefix+"_constitutional_cna_caller_gatk"]|default(false) %}
             {% for normal in normSamples.values() if normal.assayCode == sample.assayCode and normal.gatkCnvPon is defined %}

--- a/modules/qc/bam_qc_constitutional_dna.jst
+++ b/modules/qc/bam_qc_constitutional_dna.jst
@@ -146,6 +146,7 @@
   {% set output %}{{ results_dir }}/{{ bam|basename }}.sexCheck.txt{% endset %}
   {% set sample_lb_output %}{{ results_dir }}/{{ sample.name }}_{{ sample_lb }}.{{ aligner }}.bam.sexCheck.txt{% endset %}
   {% set json %}{{ results_dir }}/{{ sample.name }}_{{ sample_lb }}.{{ aligner }}.bam.sexCheck.json{% endset %}
+  {% set config_sex %}{{ sex|default("Unknown") }}{% endset %}
 
 - name: freebayes_sex_check_{{ task }}
   tags: [{{ sample.gltype }}, quality_control, constitutional_sex_check, freebayes, {{ sample.name }}]
@@ -396,10 +397,10 @@
     fi
 
     {# Print header #}
-    echo -e BAM"\t"SAMPLE"\t"POSITIONS_GENOTYPED"\t"MISSING_GENOTYPES"\t"TESTED_GENOTYPES"\t"HOMOZYGOUS_TOTAL"\t"HOMOZYGOUS_REFERENCE"\t"HOMOZYGOUS_ALTERNATE"\t"HETEROZYGOUS"\t"HOMOZYGOUS_RATE"\t"HOMOZYGOUS_RATE_SEX_PREDICTION"\t"B_ALLELE_GENOTYPES"\t"BB_ALT_RATE"\t"BB_ALT_RATE_SEX_PREDICTION"\t"READS_ON_X"\t"READS_ON_Y"\t"TOTAL_SEX_CHR_READS"\t"Y_READS_SEX_CHR_RATIO"\t"READ_COUNT_SEX_PREDICTION"\t"SEX_PREDICTION"\t"SEX_PREDICTION_CONFIDENCE > {{ output }}
+    echo -e BAM"\t"SAMPLE"\t"POSITIONS_GENOTYPED"\t"MISSING_GENOTYPES"\t"TESTED_GENOTYPES"\t"HOMOZYGOUS_TOTAL"\t"HOMOZYGOUS_REFERENCE"\t"HOMOZYGOUS_ALTERNATE"\t"HETEROZYGOUS"\t"HOMOZYGOUS_RATE"\t"HOMOZYGOUS_RATE_SEX_PREDICTION"\t"B_ALLELE_GENOTYPES"\t"BB_ALT_RATE"\t"BB_ALT_RATE_SEX_PREDICTION"\t"READS_ON_X"\t"READS_ON_Y"\t"TOTAL_SEX_CHR_READS"\t"Y_READS_SEX_CHR_RATIO"\t"READ_COUNT_SEX_PREDICTION"\t"SEX_PREDICTION"\t"SEX_PREDICTION_CONFIDENCE"\t"EXPECTED_SEX > {{ output }}
 
     {# Print results #}
-    echo -e {{ bam|basename }}"\t"${SAMPLE}"\t"${POSITIONS_GENOTYPED}"\t"${MISSING_GENOTYPES}"\t"${TESTED_GENOTYPES}"\t"${HOMOZYGOUS_TOTAL}"\t"${HOMOZYGOUS_REFERENCE}"\t"${HOMOZYGOUS_ALTERNATE}"\t"${HETEROZYGOUS}"\t"${HOMOZYGOUS_RATE}"\t"${HOMOZYGOUS_RATE_SEX_PREDICTION}"\t"${B_ALLELE_GENOTYPES}"\t"${BB_ALT_RATE}"\t"${BB_ALT_RATE_SEX_PREDICTION}"\t"${READS_ON_X}"\t"${READS_ON_Y}"\t"${TOTAL_SEX_CHR_READS}"\t"${Y_READS_SEX_CHR_RATIO}"\t"${READ_COUNT_SEX_PREDICTION}"\t"${SEX_PREDICTION}"\t"${SEX_PREDICTION_CONFIDENCE} >> {{ output }}
+    echo -e {{ bam|basename }}"\t"${SAMPLE}"\t"${POSITIONS_GENOTYPED}"\t"${MISSING_GENOTYPES}"\t"${TESTED_GENOTYPES}"\t"${HOMOZYGOUS_TOTAL}"\t"${HOMOZYGOUS_REFERENCE}"\t"${HOMOZYGOUS_ALTERNATE}"\t"${HETEROZYGOUS}"\t"${HOMOZYGOUS_RATE}"\t"${HOMOZYGOUS_RATE_SEX_PREDICTION}"\t"${B_ALLELE_GENOTYPES}"\t"${BB_ALT_RATE}"\t"${BB_ALT_RATE_SEX_PREDICTION}"\t"${READS_ON_X}"\t"${READS_ON_Y}"\t"${TOTAL_SEX_CHR_READS}"\t"${Y_READS_SEX_CHR_RATIO}"\t"${READ_COUNT_SEX_PREDICTION}"\t"${SEX_PREDICTION}"\t"${SEX_PREDICTION_CONFIDENCE}"\t"{{ config_sex }} >> {{ output }}
 
     {% if libraryCount == 1 %}
       cp {{ output }} {{ sample_lb_output }}

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -203,7 +203,7 @@
           --min_junction_reads 1 \
           --min_novel_junction_support 3 \
           --min_spanning_frags_only 5 \
-          --STAR_max_mate_dist 100000 \
+          --max_mate_dist 100000 \
           --vis \
           --max_promiscuity 10 \
           --output_dir {{ temp_dir }} \

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -197,8 +197,10 @@
     if (( NUM_FUSIONS == 0 )); then
         echo "Zero fusions found, skipping FusionInspector"
     else
+        PROJECT_ROOT=$PWD
+        cd {{ temp_dir }}
         FusionInspector \
-          --fusions {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv \
+          --fusions ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv \
           --out_prefix {{ sample.name }}_finspector \
           --min_junction_reads 1 \
           --min_novel_junction_support 3 \
@@ -206,30 +208,30 @@
           --max_mate_dist 100000 \
           --vis \
           --max_promiscuity 10 \
-          --output_dir {{ temp_dir }} \
+          --output_dir FusionInspector-inspect \
           --genome_lib_dir {{ constants.tempe.starfusion_index }} \
           --CPU 2 \
           --only_fusion_reads \
           --fusion_contigs_only \
-          --left_fq {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq \
-          --right_fq {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq \
+          --left_fq ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq \
+          --right_fq ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq \
           --no_FFPM \
           --include_Trinity \
           --annotate \
           --examine_coding_effect
 
         {# Moving fusion inspector files to results dir #}
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.bed {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.fa {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.junction_reads.bam {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.spanning_reads.bam {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz {{ results_dir }}/
-        mv {{ temp_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi {{ results_dir }}/
-        mv {{ temp_dir }}/fi_workdir/trinity_GG/Trinity-GG.fasta {{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
+        mv FusionInspector-inspect/finspector.bed ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.bed
+        mv FusionInspector-inspect/finspector.fa ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fa
+        mv FusionInspector-inspect/finspector.fusion_inspector_web.html ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html
+        mv FusionInspector-inspect/finspector.fusion_inspector_web.json ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json
+        mv FusionInspector-inspect/finspector.junction_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam
+        mv FusionInspector-inspect/finspector.junction_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai
+        mv FusionInspector-inspect/finspector.spanning_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam
+        mv FusionInspector-inspect/finspector.spanning_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai
+        mv FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz
+        mv FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi
+        mv FusionInspector-inspect/fi_workdir/trinity_GG/Trinity-GG.fasta ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
     fi
 
 {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -37,8 +37,11 @@
   {% endfor %}
     - {{ constants.tempe.starfusion_index }}
   output:
-    - {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam
     - {{ results_dir }}/{{ sample.name }}_Chimeric.out.junction
+    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
+    - {{ results_dir }}/{{ sample.name }}_starfusion.bam
+    - {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
+    {% endif %}
   cpus: 20
   mem: 80G
   walltime: "24:00:00"
@@ -104,6 +107,11 @@
 
     samtools index -@ 20 {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam
 
+    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
+    mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam {{ results_dir }}/{{ sample.name }}_starfusion.bam
+    mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam.bai {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
+    {% endif %}
+
     mv {{ temp_dir }}/Chimeric.out.junction {{ results_dir }}/{{ sample.name }}_Chimeric.out.junction
 
 
@@ -111,7 +119,6 @@
   tags: [{{ sample.gltype }}, transcriptome, fusion_caller, STAR_Fusion, {{ sample.name }}]
   input:
     - {{ results_dir }}/{{ sample.name }}_Chimeric.out.junction
-    - {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam
     {% for fq in r1fqlist %}
     - {{ fq.path }}
     {% endfor %}
@@ -125,10 +132,6 @@
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq
-    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
-    - {{ results_dir }}/{{ sample.name }}_starfusion.bam
-    - {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
-    {% endif %}
   cpus: 4
   mem: 8G
   walltime: "24:00:00"
@@ -139,8 +142,6 @@
     set -eu
     set -o pipefail
 
-    export PATH="$PATH:/usr/local/src/STAR-Fusion/"
-
     STAR-Fusion \
       --CPU 4 \
       --genome_lib_dir "{{ constants.tempe.starfusion_index }}" \
@@ -149,7 +150,6 @@
       --right_fq "{{ r2fqlist|map(attribute='path')|join(',') }}" \
       --examine_coding_effect \
       --extract_fusion_reads \
-      --FusionInspector inspect \
       --denovo_reconstruct \
       --output_dir "{{ temp_dir }}" \
       --outTmpDir "{{ temp_dir }}" \
@@ -161,28 +161,76 @@
     mv {{ temp_dir }}/star-fusion.fusion_predictions.abridged.tsv {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.tsv
     mv {{ temp_dir }}/star-fusion.fusion_predictions.tsv {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.tsv
 
+- name: fusion_inspector_{{ sample.name }}
+  tags: [{{ sample.gltype }}, transcriptome, fusion_caller, STAR_Fusion, {{ sample.name }}]
+  input:
+    - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv
+    - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq
+    - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq
+  output:
+    - {{ results_dir }}/{{ sample.name }}_finspector.bed
+    - {{ results_dir }}/{{ sample.name }}_finspector.fa
+    - {{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html
+    - {{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json
+    - {{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam
+    - {{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai
+    - {{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam
+    - {{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai
+    - {{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz
+    - {{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi
+    - {{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
+  cpus: 2
+  mem: 16G
+  walltime: "24:00:00"
+  queue_preset: "DEFAULT"
+  container: {{ constants.tools.star_fusion.container }}
+  digest: {{ constants.tools.star_fusion.digest }}
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    rm -r {{ temp_dir }} || true
+    mkdir -p {{ temp_dir }}
+    mkdir -p {{ results_dir }}
+
     NUM_FUSIONS=$(grep -w "#FusionName" -c -v {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv || :)
     if (( NUM_FUSIONS == 0 )); then
-        echo "Zero fusions found, no FusionInspector results will exist, skipping moves"
+        echo "Zero fusions found, skipping FusionInspector"
     else
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.bed {{ results_dir }}/{{ sample.name }}_finspector.bed
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.fa {{ results_dir }}/{{ sample.name }}_finspector.fa
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.fusion_inspector_web.html {{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.fusion_inspector_web.json {{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.junction_reads.bam {{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.junction_reads.bam.bai {{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.spanning_reads.bam {{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.spanning_reads.bam.bai {{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz {{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz
-        mv {{ temp_dir }}/FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi {{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi
-        mv {{ temp_dir }}/FusionInspector-inspect/fi_workdir/trinity_GG/Trinity-GG.fasta {{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
+        FusionInspector \
+          --fusions {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv \
+          --out_prefix {{ sample.name }}_finspector \
+          --min_junction_reads 1 \
+          --min_novel_junction_support 3 \
+          --min_spanning_frags_only 5 \
+          --STAR_max_mate_dist 100000 \
+          --vis \
+          --max_promiscuity 10 \
+          --output_dir {{ temp_dir }} \
+          --genome_lib_dir {{ constants.tempe.starfusion_index }} \
+          --CPU 2 \
+          --only_fusion_reads \
+          --fusion_contigs_only \
+          --left_fq {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq \
+          --right_fq {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq \
+          --no_FFPM \
+          --include_Trinity \
+          --annotate \
+          --examine_coding_effect
+
+        {# Moving fusion inspector files to results dir #}
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.bed {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.fa {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.junction_reads.bam {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.spanning_reads.bam {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz {{ results_dir }}/
+        mv {{ temp_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi {{ results_dir }}/
+        mv {{ temp_dir }}/fi_workdir/trinity_GG/Trinity-GG.fasta {{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
     fi
-
-    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
-    mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam {{ results_dir }}/{{ sample.name }}_starfusion.bam
-    mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam.bai {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
-    {% endif %}
-
 
 {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
 {% if cram|default(true) %}
@@ -194,6 +242,7 @@
   tags: [{{ sample.gltype }}, {{ sample.name }}, bam_to_cram ]
   input: 
     - {{ results_dir }}/{{ sample.name }}_starfusion.bam
+    - {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
     - {{ constants.tempe.star_fasta }}
   output:
     - {{ results_dir }}/{{ sample.name }}_starfusion.cram

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -150,7 +150,6 @@
       --right_fq "{{ r2fqlist|map(attribute='path')|join(',') }}" \
       --examine_coding_effect \
       --extract_fusion_reads \
-      --denovo_reconstruct \
       --output_dir "{{ temp_dir }}" \
       --outTmpDir "{{ temp_dir }}" \
       --tmpdir "{{ temp_dir }}"

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -167,6 +167,7 @@
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_predictions.abridged.coding_effect.tsv
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_1.fq
     - {{ results_dir }}/{{ sample.name }}_star_fusion.fusion_evidence_reads_2.fq
+    - {{ constants.tempe.starfusion_index }}
   output:
     - {{ results_dir }}/{{ sample.name }}_finspector.bed
     - {{ results_dir }}/{{ sample.name }}_finspector.fa

--- a/modules/rna/star_fusion.jst
+++ b/modules/rna/star_fusion.jst
@@ -222,16 +222,16 @@
           --examine_coding_effect
 
         {# Moving fusion inspector files to results dir #}
-        mv FusionInspector-inspect/finspector.bed ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.bed
-        mv FusionInspector-inspect/finspector.fa ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fa
-        mv FusionInspector-inspect/finspector.fusion_inspector_web.html ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.html
-        mv FusionInspector-inspect/finspector.fusion_inspector_web.json ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.fusion_inspector_web.json
-        mv FusionInspector-inspect/finspector.junction_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam
-        mv FusionInspector-inspect/finspector.junction_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.junction_reads.bam.bai
-        mv FusionInspector-inspect/finspector.spanning_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam
-        mv FusionInspector-inspect/finspector.spanning_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.spanning_reads.bam.bai
-        mv FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz
-        mv FusionInspector-inspect/finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.bed ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.fa ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.fusion_inspector_web.html ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.fusion_inspector_web.json ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.junction_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.junction_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.spanning_reads.bam ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.spanning_reads.bam.bai ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz ${PROJECT_ROOT}/{{ results_dir }}/
+        mv FusionInspector-inspect/{{ sample.name }}_finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed.gz.tbi ${PROJECT_ROOT}/{{ results_dir }}/
         mv FusionInspector-inspect/fi_workdir/trinity_GG/Trinity-GG.fasta ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
     fi
 

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -115,8 +115,8 @@ constants:
       container: ghcr.io/tgen/jetstream_containers/vardict:1.7.9
       digest: 0f7e273e1c7f7f74c285b9d1e04fd484f5fc1fa767bb9a0b7a077ae5da21eabc
     vcfmerger:
-      container: ghcr.io/tgen/jetstream_containers/vcfmerger2:0.9.3
-      digest: 2b1727deba0e206b192a44115ed9e5d7a961e9d23e093687409d4f2f8a2fbeb6
+      container: ghcr.io/tgen/jetstream_containers/vcfmerger2:0.9.4
+      digest: 54b068b9dde256e0617379bc772268ff291f570fef68d495a540a7d49b2f155a
     vep:
       container: ghcr.io/tgen/jetstream_containers/ensembl-vep:release_107.0
       digest: 2762c6efff95ecac45bcb1dfccdb7c139e2cc4700b855b68632dcdf45d9c7712

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -95,7 +95,7 @@ constants:
       digest: 37e2122779da2b840817a509b84e43f627a77e310e4b6d2814abde5459c2e246
     sigprofiler:
       container: ghcr.io/tgen/jetstream_containers/sigprofiler:0.0.21
-      digest: 36f0ef1529efb77212654bb6ec3d359facff2d7a0302edcbf64dafc4895a923b
+      digest: e23822b423d46434fbc8a43008ec579c636b32b45c31a95b16b0180cc13e7734
     snpeff:
       container: ghcr.io/tgen/jetstream_containers/snpeff:4_3t
       digest: bd1aa0314843e414388330f6fe69bc442459c18de7999e9c91afaeef2c05a02d

--- a/utilities/md5sum_bam_cram.jst
+++ b/utilities/md5sum_bam_cram.jst
@@ -14,11 +14,11 @@
     - {{ file_path }}/{{ sample.name }}.{{ aligner }}.bam.bai
   output:
     {% if cram|default(true) %}
-    - {{ sample.name }}.{{ aligner }}.cram.md5
-    - {{ sample.name }}.{{ aligner }}.cram.crai.md5
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.cram.md5
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.cram.crai.md5
     {% endif %}
-    - {{ sample.name }}.{{ aligner }}.bam.md5
-    - {{ sample.name }}.{{ aligner }}.bam.bai.md5
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.bam.md5
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.bam.bai.md5
   walltime: "1:00:00"
   cpus: 1
   mem: 2G


### PR DESCRIPTION
### Handful of updates with this PR (Pseudo release notes)
Fixes:
* FusionInspector has been broken out to a separate task similar to how we've run things in previous pipelines - previous implementation generated FusionInspector results, but due to naming differences, these results were not landing in the results_dir
* Moved expansion hunter to only run for normals and slight reorganization of constitutional main
* md5sum_bam_cram output pathing fixes, important for smart copy
* Edge case bugfix for vcfMerger - bump to v0.9.4
* SigprofilerAssignment bugfix to handle cases where DINUC matrices are not generated

Features:
* Resolving #6 - as requested back in the phoenix pipeline

Additional features/bugfixes are expected soon for a v1.2.0 release - Most of these are multiple myeloma focused, but as a preview we will be resolving #15 and #17, enabling the mm_igtx workflows, etc. A major note is that v1.2.0 will cause restarts by nature of resolving #15 and #17, part of this addition is the move to samtools v1.17.