### PR TITLE
Adjustments before v1.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,42 +139,49 @@ MMRF_1499
 ## Required Software
 
 All tools are available as OCI images [here](https://github.com/orgs/tgen/packages)
-_Last Updated Aug 31st, 2023_  
+_Last Updated Sep 1st, 2023_  
 
 | Tool | Version Implemented | Current Version |
 | :---: | :---: | :---: |
-| [bcftools](https://github.com/samtools/bcftools/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbcftools) | [1.18](https://github.com/samtools/bcftools/releases/tag/1.18) |
-| [bedtools](https://github.com/arq5x/bedtools2/releases) | [2.29.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbedtools) | [2.31.0](https://github.com/arq5x/bedtools2/releases/tag/v2.31.0) |
-| [bwa-mem2](https://github.com/bwa-mem2/bwa-mem2) | [2.2.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbwa_mem2_samtools) | [2.2.1](https://github.com/bwa-mem2/bwa-mem2/releases/tag/v2.2.1) |
-| [deepvariant](https://github.com/google/deepvariant/releases) | [1.5.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fdeepvariant) | [1.5.0](https://github.com/google/deepvariant/releases/tag/v1.5.0) |
-| [expansion_hunter](https://github.com/Illumina/ExpansionHunter/releases) | [4.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fexpansion_hunter) | [5.0.0](https://github.com/Illumina/ExpansionHunter/releases/tag/v5.0.0) |
-| [fgbio](https://github.com/fulcrumgenomics/fgbio/releases) | [2.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffgbio) | [2.1.0](https://github.com/fulcrumgenomics/fgbio/releases/tag/2.1.0) |
-| [freebayes](https://github.com/ekg/freebayes/releases) | [1.3.6](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffreebayes) | [1.3.7](https://github.com/freebayes/freebayes/releases/tag/v1.3.7) |
-| [gatk](https://github.com/broadinstitute/gatk//releases) | [4.4.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fgatk) | [4.4.0.0](https://github.com/broadinstitute/gatk/releases/tag/4.4.0.0) |
-| [hmmcopyutils](https://github.com/shahcompbio/hmmcopy_utils) | [0.1.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhmmcopy-utils) | [0.1.1](http://compbio.bccrc.ca/software/hmmcopy/) |
-| [htslib](https://github.com/samtools/htslib/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhtslib) | [1.18](https://github.com/samtools/htslib/releases/tag/1.18) |
-| [ichor](https://github.com/GavinHaLab/ichorCNA/releases) | [0.5.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fichorcna) | [0.5.0](https://github.com/GavinHaLab/ichorCNA/releases/tag/v0.5.0) |
-| [lancet](https://github.com/nygenome/lancet/releases) | [1.1.x](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Flancet) | [1.1.0](https://github.com/nygenome/lancet/releases/tag/v1.1.0) |
-| [manta](https://github.com/Illumina/manta/releases) | [1.6.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmanta) | [1.6.0](https://github.com/Illumina/manta/releases/tag/v1.6.0) |
-| [msisensor](https://github.com/xjtu-omics/msisensor-pro) | [1.1.a](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmsisensor) | [1.2.0](https://github.com/xjtu-omics/msisensor-pro/releases/tag/v1.2.0) |
-| [multiQC](https://github.com/ewels/MultiQC/releases) | [1.13](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmultiqc) | [1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) |
-| [octopus](https://github.com/luntergroup/octopus/releases) | [0.7.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Foctopus) | [0.7.4](https://github.com/luntergroup/octopus/releases/tag/v0.7.4) |
-| [python3](https://www.python.org/downloads/) | [3.7.16](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fpython) | [3.11.5](https://www.python.org/downloads/release/python-3115/) |
-| [parabricks](https://docs.nvidia.com/clara/#parabricks) | [4.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fclara-parabricks) | [4.1.2](https://docs.nvidia.com/clara/parabricks/latest/index.html) |
-| [R](https://www.r-project.org/) | [4.1.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fr-with_modules) | [4.3.1](https://stat.ethz.ch/pipermail/r-announce/2023/000694.html) |
+| [bcftools](https://github.com/samtools/bcftools/releases) | [1.17](ghcr.io/tgen/containers/bcftools:1.17-23080313) | [1.18](https://github.com/samtools/bcftools/releases/tag/1.18) |
+| [bedtools](https://github.com/arq5x/bedtools2/releases) | [2.29.0](ghcr.io/tgen/containers/bedtools:2.29.0-23080313) | [2.31.0](https://github.com/arq5x/bedtools2/releases/tag/v2.31.0) |
+| [bpure](https://github.com/tgen/b_pure) | [1.0.0](ghcr.io/tgen/containers/b_pure:1.0.0) | [1.0.0](https://github.com/tgen/b_pure) |
+| [bwa-mem2](https://github.com/bwa-mem2/bwa-mem2) | [2.2.1](ghcr.io/tgen/containers/bwa_mem2_samtools:2.2.1-23080315) | [2.2.1](https://github.com/bwa-mem2/bwa-mem2/releases/tag/v2.2.1) |
+| [deepvariant](https://github.com/google/deepvariant/releases) | [1.5.0](https://hub.docker.com/r/google/deepvariant/tags) | [1.5.0](https://github.com/google/deepvariant/releases/tag/v1.5.0) |
+| [discordant_loci_extractor](https://github.com/tgen/Discordant_Loci_Extractor) | [0.1.5](ghcr.io/tgen/containers/discordant_loci_extractor:0.1.5-23080815) | [0.1.5](https://github.com/tgen/Discordant_Loci_Extractor/releases/tag/v0.1.5)
+| [expansion_hunter](https://github.com/Illumina/ExpansionHunter/releases) | [4.0.2](ghcr.io/tgen/containers/expansion_hunter:4.0.2-23080316) | [5.0.0](https://github.com/Illumina/ExpansionHunter/releases/tag/v5.0.0) |
+| [fgbio](https://github.com/fulcrumgenomics/fgbio/releases) | [2.0.2](ghcr.io/tgen/containers/fgbio:2.0.2-23082819) | [2.1.0](https://github.com/fulcrumgenomics/fgbio/releases/tag/2.1.0) |
+| [freebayes](https://github.com/ekg/freebayes/releases) | [1.3.6](quay.io/biocontainers/freebayes:1.3.6--h6f59eb7_3) | [1.3.7](https://github.com/freebayes/freebayes/releases/tag/v1.3.7) |
+| [gatk](https://github.com/broadinstitute/gatk/releases) | [4.4.0.0](https://hub.docker.com/r/broadinstitute/gatk/tags) | [4.4.0.0](https://github.com/broadinstitute/gatk/releases/tag/4.4.0.0) |
+| [hmmcopy](https://github.com/shahcompbio/hmmcopy_utils) | [0.1.1](quay.io/biocontainers/hmmcopy:0.1.1--h8b12597_4) | [0.1.1](http://compbio.bccrc.ca/software/hmmcopy/) |
+| [htslib](https://github.com/samtools/htslib/releases) | [1.17](ghcr.io/tgen/containers/htslib:1.17-23080709) | [1.18](https://github.com/samtools/htslib/releases/tag/1.18) |
+| [ichor](https://github.com/GavinHaLab/ichorCNA/releases) | [0.5.0](quay.io/biocontainers/r-ichorcna:0.5.0--pl5321r43hdfd78af_1) | [0.5.0](https://github.com/GavinHaLab/ichorCNA/releases/tag/v0.5.0) |
+| [lancet](https://github.com/nygenome/lancet/releases) | [1.1.x](ghcr.io/tgen/containers/lancet:1.1.x-23080709) | [1.1.0](https://github.com/nygenome/lancet/releases/tag/v1.1.0) |
+| [manta](https://github.com/Illumina/manta/releases) | [1.6.0](ghcr.io/tgen/containers/manta:1.6.0-23082819) | [1.6.0](https://github.com/Illumina/manta/releases/tag/v1.6.0) |
+| [manta_tgen](https://github.com/tgen/manta/releases) | [1.6.0](ghcr.io/tgen/containers/manta_tgen:1.6.0-23082819) | [1.6.0](https://github.com/tgen/manta/releases/tag/v1.6.0) |
+| [msisensor](https://github.com/xjtu-omics/msisensor-pro) | [1.1.a](ghcr.io/tgen/containers/msisensor:1.1.a-23080815) | [1.2.0](https://github.com/xjtu-omics/msisensor-pro/releases/tag/v1.2.0) |
+| [multiQC](https://github.com/ewels/MultiQC/releases) | [1.13](quay.io/biocontainers/multiqc:1.13--pyhdfd78af_0) | [1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) |
+| [octopus](https://github.com/luntergroup/octopus/releases) | [0.7.4](ghcr.io/tgen/containers/octopus:0.7.4-23080809) | [0.7.4](https://github.com/luntergroup/octopus/releases/tag/v0.7.4) |
+| [pairoscope](https://github.com/genome/pairoscope) | [0.4.2](ghcr.io/tgen/containers/pairoscope:0.4.2-23080810) | [0.4.2](https://github.com/genome/pairoscope/releases/tag/v0.4.2) |
+| [parabricks](https://docs.nvidia.com/clara/#parabricks) | [4.0.0](nvcr.io/nvidia/clara/clara-parabricks:4.0.0-1) | [4.1.2](https://docs.nvidia.com/clara/parabricks/latest/index.html) |
+| [python3](https://www.python.org/downloads/) | [3.7.16](https://hub.docker.com/_/python/tags?page=1&name=3.7.16) | [3.11.5](https://www.python.org/downloads/release/python-3115/) |
+| [R](https://www.r-project.org/) | [4.1.2](ghcr.io/tgen/containers/r_with_modules:4.1.2-23080815) | [4.3.1](https://stat.ethz.ch/pipermail/r-announce/2023/000694.html) |
+| [salmon](https://github.com/COMBINE-lab/salmon/releases) | [1.9.0](https://hub.docker.com/r/combinelab/salmon/tags) | [1.10.1](https://github.com/COMBINE-lab/salmon/releases/tag/v1.10.1) |
+| [samtools](https://github.com/samtools/samtools/releases) | [1.17](ghcr.io/tgen/containers/samtools:1.17-23080815) | [1.18](https://github.com/samtools/samtools/releases/tag/1.18) |
+| [sigprofiler](https://github.com/AlexandrovLab/SigProfilerAssignment/releases) | [0.0.24](ghcr.io/tgen/containers/sigprofiler:0.0.24-23080710) | [0.0.31](https://github.com/AlexandrovLab/SigProfilerAssignment/releases/tag/v0.0.31) |
+| [snpSniffer](https://github.com/tgen/snpSniffer/releases) | [7.0.0](ghcr.io/tgen/containers/snpsniffer:7.0.0-23080810) | [7.0.0](https://github.com/tgen/snpSniffer/releases/tag/v7.0.0) |
+| [star-fusion](https://github.com/STAR-Fusion/STAR-Fusion/releases) | [1.11.0](https://hub.docker.com/r/trinityctat/starfusion/tags) | [1.12.0](https://github.com/STAR-Fusion/STAR-Fusion/releases/tag/STAR-Fusion-v1.12.0) |
+| [strelka](https://github.com/Illumina/strelka/releases) | [2.9.10](ghcr.io/tgen/containers/strelka:2.9.10-23080711) | [2.9.10](https://github.com/Illumina/strelka/releases) |
+| [subread](https://sourceforge.net/projects/subread/) | [2.0.0](quay.io/biocontainers/subread:2.0.0--hed695b0_0) | [2.0.6](https://sourceforge.net/projects/subread/files/subread-2.0.6/) |
+| [tgen_mutation_burden](https://github.com/tgen/tgen_mutation_burden/releases) | [1.2.4](ghcr.io/tgen/containers/mutation-burden:1.2.4-23080815) | [1.2.4](https://github.com/tgen/tgen_mutation_burden/releases/tag/v1.2.4) |
 | [thred](https://github.com/tgen/tHReD) | [1.1.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fthred) | [1.1.0](https://github.com/tgen/tHReD/releases/tag/1.1.0) |
-| [salmon](https://github.com/COMBINE-lab/salmon/releases) | [1.9.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsalmon) | [1.10.1](https://github.com/COMBINE-lab/salmon/releases/tag/v1.10.1) |
-| [sigprofiler](https://github.com/AlexandrovLab/SigProfilerAssignment/releases) | [0.0.24](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsigprofiler) | [0.0.31](https://github.com/AlexandrovLab/SigProfilerAssignment/releases/tag/v0.0.31) |
-| [samtools](https://github.com/samtools/samtools/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsamtools) | [1.18](https://github.com/samtools/samtools/releases/tag/1.18) |
-| [snpSniffer](https://github.com/tgen/snpSniffer/releases) | [7.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsnpsniffer) | [7.0.0](https://github.com/tgen/snpSniffer/releases/tag/v7.0.0) |
-| [star-fusion](https://github.com/STAR-Fusion/STAR-Fusion/releases) | [1.11.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstar_fusion) | [1.12.0](https://github.com/STAR-Fusion/STAR-Fusion/releases/tag/STAR-Fusion-v1.12.0) |
-| [strelka](https://github.com/Illumina/strelka/releases) | [2.9.10](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstrelka) | [2.9.10](https://github.com/Illumina/strelka/releases) |
-| [subread](https://sourceforge.net/projects/subread/) | [2.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsubread) | [2.0.6](https://sourceforge.net/projects/subread/files/subread-2.0.6/) |
-| [tgen_mutation_burden](https://github.com/tgen/tgen_mutation_burden/releases) | [1.2.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmutation-burden) | [1.2.4](https://github.com/tgen/tgen_mutation_burden/releases/tag/v1.2.4) |
-| [vardictJava](https://github.com/AstraZeneca-NGS/VarDictJava/releases) | [1.8.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvardict) | [1.8.3](https://github.com/AstraZeneca-NGS/VarDictJava/releases/tag/v1.8.3) |
-| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.5](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvcfmerger2) | [0.9.5]() |
-| [vep](https://github.com/Ensembl/ensembl-vep/releases) | [107.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fensembl-vep) | [110.1](https://github.com/Ensembl/ensembl-vep/releases/tag/release%2F110.1) |
-| [verifybamid2](https://github.com/Griffan/VerifyBamID/releases) | [2.0.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fverify-bam-id2) | [2.0.1](https://github.com/Griffan/VerifyBamID/releases/tag/2.0.1) |
+| [transparser](https://github.com/tgen/transParser) | [1.0.1](ghcr.io/tgen/containers/transparser:1.0.1-23080810) | [1.0.1](https://github.com/tgen/transParser/releases/tag/v1.0.1) |
+| [trinity](https://github.com/trinityrnaseq/trinityrnaseq) | [2.8.6](ghcr.io/tgen/containers/trinity_bwa_mem2:2.8.6-23082819) | [2.15.1](https://github.com/trinityrnaseq/trinityrnaseq/releases/tag/Trinity-v2.15.1) |
+| [vardictJava](https://github.com/AstraZeneca-NGS/VarDictJava/releases) | [1.8.3](quay.io/biocontainers/vardict-java:1.8.3--hdfd78af_0) | [1.8.3](https://github.com/AstraZeneca-NGS/VarDictJava/releases/tag/v1.8.3) |
+| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.4](ghcr.io/tgen/containers/vcfmerger2:0.9.4-23080809) | [0.9.4](https://github.com/tgen/vcfMerger2/releases) |
+| [vcf2maf](https://github.com/mskcc/vcf2maf/releases) | [1.6.21](quay.io/biocontainers/vcf2maf:1.6.21--hdfd78af_0) | [1.6.21](https://github.com/mskcc/vcf2maf/releases/tag/v1.6.21) |
+| [vep](https://github.com/Ensembl/ensembl-vep/releases) | [107.0](https://hub.docker.com/r/ensemblorg/ensembl-vep/tags) | [110.1](https://github.com/Ensembl/ensembl-vep/releases/tag/release%2F110.1) |
+| [verifybamid2](https://github.com/Griffan/VerifyBamID/releases) | [2.0.1](https://hub.docker.com/r/griffan/verifybamid2/tags) | [2.0.1](https://github.com/Griffan/VerifyBamID/releases/tag/2.0.1) |
 
 ## Install Guide
 

--- a/README.md
+++ b/README.md
@@ -139,43 +139,42 @@ MMRF_1499
 ## Required Software
 
 All tools are available as OCI images [here](https://github.com/orgs/tgen/packages)
-_Last Updated Dec 20th, 2022_  
+_Last Updated Aug 31st, 2023_  
 
-| Tool | Version Implemented |
-| :---: | :---: |
-| [bcftools](https://github.com/samtools/bcftools/releases) | [1.16](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbcftools) |
-| [bedtools](https://github.com/arq5x/bedtools2/releases) | [2.29.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbedtools) |
-| [bwa-mem2](https://github.com/lh3/bwa/releases) | [2.2.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbwa_mem2_samtools) |
-| [deepvariant-cpu](https://github.com/google/deepvariant/releases) | [1.4.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fdeepvariant) |
-| [deepvariant-gpu](https://github.com/google/deepvariant/releases) | [1.4.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fdeepvariant) |
-| [expansion_hunter](https://github.com/Illumina/ExpansionHunter/releases) | [4.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fexpansion_hunter) |
-| [fgbio](https://github.com/fulcrumgenomics/fgbio/releases) | [2.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffgbio) |
-| [freebayes](https://github.com/ekg/freebayes/releases) | [1.3.6](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffreebayes) |
-| [gatk](https://github.com/broadinstitute/gatk//releases) | [4.1.8.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fgatk) |
-| [hmmcopyutils](https://github.com/shahcompbio/hmmcopy_utils) | [1.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhmmcopy-utils) |
-| [htslib](https://github.com/samtools/htslib/releases) | [1.16](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhtslib) |
-| [ichor](https://github.com/broadinstitute/ichorCNA/releases) | [0.2.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fichorcna) |
-| [lancet](https://github.com/nygenome/lancet/releases) | [1.1.x](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Flancet) |
-| [manta](https://github.com/Illumina/manta/releases) | [1.6.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmanta) |
-| [msisensor](https://github.com/xjtu-omics/msisensor-pro) | [1.1.a](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmsisensor) |
-| [multiQC](https://github.com/ewels/MultiQC/releases) | [1.13](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmultiqc) |
-| [octopus](https://github.com/luntergroup/octopus/releases) | [0.7.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Foctopus) |
-| [python3](https://www.python.org/downloads/) | [3.7.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fpython) |
-| [parabricks](https://docs.nvidia.com/clara/#parabricks) | [4.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fclara-parabricks) |
-| [R](https://www.r-project.org/) | [3.6.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fr-with_modules) |
-| [thred](https://github.com/tgen/tHReD) | [1.1.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fthred) |
-| [salmon](https://github.com/COMBINE-lab/salmon/releases) | [1.9.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsalmon) |
-| [sigprofiler](https://github.com/AlexandrovLab/SigProfilerAssignment/releases) | [0.0.21](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsigprofiler) |
-| [samtools](https://github.com/samtools/samtools/releases) | [1.16.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsamtools) |
-| [snpSniffer](https://github.com/tgen/snpSniffer/releases) | [7.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsnpsniffer) |
-| [star-fusion](https://github.com/STAR-Fusion/STAR-Fusion/releases) | [1.11.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstar_fusion) |
-| [strelka](https://github.com/Illumina/strelka/releases) | [2.9.10](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstrelka) |
-| [subread](https://sourceforge.net/projects/subread/) | [2.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsubread) |
-| [tgen_mutation_burden](https://github.com/tgen/tgen_mutation_burden/releases) | [1.2.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmutation-burden) |
-| [vardictJava](https://github.com/AstraZeneca-NGS/VarDictJava/releases) | [1.7.9](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvardict) |
-| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.3](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvcfmerger2) |
-| [vep](https://github.com/Ensembl/ensembl-vep/releases) | [107.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fensembl-vep) |
-| [verifybamid2](https://github.com/Griffan/VerifyBamID/releases) | [2.0.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fverify-bam-id2) |
+| Tool | Version Implemented | Current Version |
+| :---: | :---: | :---: |
+| [bcftools](https://github.com/samtools/bcftools/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbcftools) | [1.18](https://github.com/samtools/bcftools/releases/tag/1.18) |
+| [bedtools](https://github.com/arq5x/bedtools2/releases) | [2.29.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbedtools) | [2.31.0](https://github.com/arq5x/bedtools2/releases/tag/v2.31.0) |
+| [bwa-mem2](https://github.com/bwa-mem2/bwa-mem2) | [2.2.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fbwa_mem2_samtools) | [2.2.1](https://github.com/bwa-mem2/bwa-mem2/releases/tag/v2.2.1) |
+| [deepvariant](https://github.com/google/deepvariant/releases) | [1.5.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fdeepvariant) | [1.5.0](https://github.com/google/deepvariant/releases/tag/v1.5.0) |
+| [expansion_hunter](https://github.com/Illumina/ExpansionHunter/releases) | [4.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fexpansion_hunter) | [5.0.0](https://github.com/Illumina/ExpansionHunter/releases/tag/v5.0.0) |
+| [fgbio](https://github.com/fulcrumgenomics/fgbio/releases) | [2.0.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffgbio) | [2.1.0](https://github.com/fulcrumgenomics/fgbio/releases/tag/2.1.0) |
+| [freebayes](https://github.com/ekg/freebayes/releases) | [1.3.6](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Ffreebayes) | [1.3.7](https://github.com/freebayes/freebayes/releases/tag/v1.3.7) |
+| [gatk](https://github.com/broadinstitute/gatk//releases) | [4.4.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fgatk) | [4.4.0.0](https://github.com/broadinstitute/gatk/releases/tag/4.4.0.0) |
+| [hmmcopyutils](https://github.com/shahcompbio/hmmcopy_utils) | [0.1.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhmmcopy-utils) | [0.1.1](http://compbio.bccrc.ca/software/hmmcopy/) |
+| [htslib](https://github.com/samtools/htslib/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fhtslib) | [1.18](https://github.com/samtools/htslib/releases/tag/1.18) |
+| [ichor](https://github.com/GavinHaLab/ichorCNA/releases) | [0.5.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fichorcna) | [0.5.0](https://github.com/GavinHaLab/ichorCNA/releases/tag/v0.5.0) |
+| [lancet](https://github.com/nygenome/lancet/releases) | [1.1.x](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Flancet) | [1.1.0](https://github.com/nygenome/lancet/releases/tag/v1.1.0) |
+| [manta](https://github.com/Illumina/manta/releases) | [1.6.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmanta) | [1.6.0](https://github.com/Illumina/manta/releases/tag/v1.6.0) |
+| [msisensor](https://github.com/xjtu-omics/msisensor-pro) | [1.1.a](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmsisensor) | [1.2.0](https://github.com/xjtu-omics/msisensor-pro/releases/tag/v1.2.0) |
+| [multiQC](https://github.com/ewels/MultiQC/releases) | [1.13](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmultiqc) | [1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) |
+| [octopus](https://github.com/luntergroup/octopus/releases) | [0.7.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Foctopus) | [0.7.4](https://github.com/luntergroup/octopus/releases/tag/v0.7.4) |
+| [python3](https://www.python.org/downloads/) | [3.7.16](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fpython) | [3.11.5](https://www.python.org/downloads/release/python-3115/) |
+| [parabricks](https://docs.nvidia.com/clara/#parabricks) | [4.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fclara-parabricks) | [4.1.2](https://docs.nvidia.com/clara/parabricks/latest/index.html) |
+| [R](https://www.r-project.org/) | [4.1.2](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fr-with_modules) | [4.3.1](https://stat.ethz.ch/pipermail/r-announce/2023/000694.html) |
+| [thred](https://github.com/tgen/tHReD) | [1.1.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fthred) | [1.1.0](https://github.com/tgen/tHReD/releases/tag/1.1.0) |
+| [salmon](https://github.com/COMBINE-lab/salmon/releases) | [1.9.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsalmon) | [1.10.1](https://github.com/COMBINE-lab/salmon/releases/tag/v1.10.1) |
+| [sigprofiler](https://github.com/AlexandrovLab/SigProfilerAssignment/releases) | [0.0.24](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsigprofiler) | [0.0.31](https://github.com/AlexandrovLab/SigProfilerAssignment/releases/tag/v0.0.31) |
+| [samtools](https://github.com/samtools/samtools/releases) | [1.17](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsamtools) | [1.18](https://github.com/samtools/samtools/releases/tag/1.18) |
+| [snpSniffer](https://github.com/tgen/snpSniffer/releases) | [7.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsnpsniffer) | [7.0.0](https://github.com/tgen/snpSniffer/releases/tag/v7.0.0) |
+| [star-fusion](https://github.com/STAR-Fusion/STAR-Fusion/releases) | [1.11.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstar_fusion) | [1.12.0](https://github.com/STAR-Fusion/STAR-Fusion/releases/tag/STAR-Fusion-v1.12.0) |
+| [strelka](https://github.com/Illumina/strelka/releases) | [2.9.10](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fstrelka) | [2.9.10](https://github.com/Illumina/strelka/releases) |
+| [subread](https://sourceforge.net/projects/subread/) | [2.0.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fsubread) | [2.0.6](https://sourceforge.net/projects/subread/files/subread-2.0.6/) |
+| [tgen_mutation_burden](https://github.com/tgen/tgen_mutation_burden/releases) | [1.2.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fmutation-burden) | [1.2.4](https://github.com/tgen/tgen_mutation_burden/releases/tag/v1.2.4) |
+| [vardictJava](https://github.com/AstraZeneca-NGS/VarDictJava/releases) | [1.8.4](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvardict) | [1.8.3](https://github.com/AstraZeneca-NGS/VarDictJava/releases/tag/v1.8.3) |
+| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.5](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fvcfmerger2) | [0.9.5]() |
+| [vep](https://github.com/Ensembl/ensembl-vep/releases) | [107.0](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fensembl-vep) | [110.1](https://github.com/Ensembl/ensembl-vep/releases/tag/release%2F110.1) |
+| [verifybamid2](https://github.com/Griffan/VerifyBamID/releases) | [2.0.1](https://github.com/orgs/tgen/packages/container/package/jetstream_containers%2Fverify-bam-id2) | [2.0.1](https://github.com/Griffan/VerifyBamID/releases/tag/2.0.1) |
 
 ## Install Guide
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ _Last Updated Sep 1st, 2023_
 | [transparser](https://github.com/tgen/transParser) | [1.0.1](ghcr.io/tgen/containers/transparser:1.0.1-23080810) | [1.0.1](https://github.com/tgen/transParser/releases/tag/v1.0.1) |
 | [trinity](https://github.com/trinityrnaseq/trinityrnaseq) | [2.8.6](ghcr.io/tgen/containers/trinity_bwa_mem2:2.8.6-23082819) | [2.15.1](https://github.com/trinityrnaseq/trinityrnaseq/releases/tag/Trinity-v2.15.1) |
 | [vardictJava](https://github.com/AstraZeneca-NGS/VarDictJava/releases) | [1.8.3](quay.io/biocontainers/vardict-java:1.8.3--hdfd78af_0) | [1.8.3](https://github.com/AstraZeneca-NGS/VarDictJava/releases/tag/v1.8.3) |
-| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.4](ghcr.io/tgen/containers/vcfmerger2:0.9.4-23080809) | [0.9.4](https://github.com/tgen/vcfMerger2/releases) |
+| [vcfmerger2](https://github.com/tgen/vcfMerger2/releases) | [0.9.5](ghcr.io/tgen/containers/vcfmerger2:0.9.5-23090712) | [0.9.5](https://github.com/tgen/vcfMerger2/releases) |
 | [vcf2maf](https://github.com/mskcc/vcf2maf/releases) | [1.6.21](quay.io/biocontainers/vcf2maf:1.6.21--hdfd78af_0) | [1.6.21](https://github.com/mskcc/vcf2maf/releases/tag/v1.6.21) |
 | [vep](https://github.com/Ensembl/ensembl-vep/releases) | [107.0](https://hub.docker.com/r/ensemblorg/ensembl-vep/tags) | [110.1](https://github.com/Ensembl/ensembl-vep/releases/tag/release%2F110.1) |
 | [verifybamid2](https://github.com/Griffan/VerifyBamID/releases) | [2.0.1](https://hub.docker.com/r/griffan/verifybamid2/tags) | [2.0.1](https://github.com/Griffan/VerifyBamID/releases/tag/2.0.1) |

--- a/modules/constitutional/chip_mutect2.j2
+++ b/modules/constitutional/chip_mutect2.j2
@@ -1,13 +1,19 @@
 {% from 'modules/annotation/main.j2' import annotate_vcfs with context %}
 
-{% macro chip_mutect2(sample, aligner='bwa', taskPrefix='Exome', control=none) %}
+{% macro chip_mutect2(sample, aligner='bwa', taskPrefix='Exome') %}
 
 {#
 We should use a PON if provided, else default to using the 1000g PON
 Task control to ensure
 #}
 
-{% if control is not none %}
+{% if controlDataFiles is defined %}
+  {% if controlDataFiles|selectattr('assayCode', 'eq', sample.assayCode)|first is defined %}
+    {% set control = controlDataFiles|selectattr('assayCode', 'eq', sample.assayCode)|first %}
+  {% endif %}
+{% endif %}
+
+{% if control is defined and control.mutect2Pon is defined %}
 {%- set panel_of_normals %}{{ control.mutect2Pon }}{% endset %}
 {% else %}
 {%- set panel_of_normals %}{{ constants.tempe.somatic_GRCh38_1000g_pon }}{% endset %}
@@ -27,7 +33,7 @@ Task control to ensure
     - {{ normal_bam }}
     - {{ constants.tempe.reference_fasta }}
     - {{ constants.tempe.gnomad_genome_mutect_germlinereference }}
-    - {{ constants.tempe.somatic_GRCh38_1000g_pon }}
+    - {{ panel_of_normals }}
   output:
   - {{ temp_dir }}/{{ loop.index }}.mutect2.chip.vcf.gz
   - {{ temp_dir }}/{{ loop.index }}.mutect2.chip.vcf.gz.stats

--- a/modules/constitutional/deepvariant.j2
+++ b/modules/constitutional/deepvariant.j2
@@ -125,6 +125,7 @@
         --ref "{{ constants.tempe.reference_fasta }}" \
         --infile "{{ sample.name }}.cvo.tfrecord.gz" \
         --outfile "${PROJECT_ROOT}/{{ all_vcf }}" \
+        --novcf_stats_report \
         --nonvariant_site_tfrecord_path "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.gvcf.tfrecord@{{ nshards }}.gz" \
         --gvcf_outfile "${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}.{{ aligner }}.deepvariant.all.g.vcf.gz"
 

--- a/modules/constitutional/main.j2
+++ b/modules/constitutional/main.j2
@@ -101,9 +101,11 @@
         {{- expansion_hunter(sample, aligner) }}
       {% endif %}
       {%- if tasks[taskPrefix+"_constitutional_cna_caller_gatk"]|default(false) %}
-        {% set normal = normSamples.values()|selectattr('assayCode', 'eq', sample.assayCode)|first %}
-        {% if normal and normal.gatkCnvPon is defined %}
-          {{- gatk_cnv_constitutional(sample, normal, aligner) }}
+        {% if normSamples.values()|selectattr('assayCode', 'eq', sample.assayCode)|first is defined %}
+          {% set normal = normSamples.values()|selectattr('assayCode', 'eq', sample.assayCode)|first is defined %}
+          {% if normal.gatkCnvPon is defined %}
+            {{- gatk_cnv_constitutional(sample, normal, aligner) }}
+          {% endif %}
         {% endif %}
       {% endif %}
     {% endif %}

--- a/modules/constitutional/main.j2
+++ b/modules/constitutional/main.j2
@@ -101,10 +101,10 @@
         {{- expansion_hunter(sample, aligner) }}
       {% endif %}
       {%- if tasks[taskPrefix+"_constitutional_cna_caller_gatk"]|default(false) %}
-        {% set normal = normSamples|selectattr('assayCode', 'eq', sample.assayCode)|first %}
+        {% set normal = normSamples.values()|selectattr('assayCode', 'eq', sample.assayCode)|first %}
         {% if normal and normal.gatkCnvPon is defined %}
           {{- gatk_cnv_constitutional(sample, normal, aligner) }}
-        {% endfor %}
+        {% endif %}
       {% endif %}
     {% endif %}
 

--- a/modules/constitutional/main.j2
+++ b/modules/constitutional/main.j2
@@ -23,91 +23,92 @@
 {% if controlDataFiles is defined %}
 {% for file in controlDataFiles %}
 
-    {% if file.rgsm is defined %}
-        {% set name %}{{ file.rgsm }}_{{ file.assayCode }}{% endset %}
-    {% else %}
-        {% set name %}{{ study }}_{{ file.assayCode }}{% endset %}
-    {% endif %}
-    {% do file.update({'name': name}) %}
+  {% if file.rgsm is defined %}
+    {% set name %}{{ file.rgsm }}_{{ file.assayCode }}{% endset %}
+  {% else %}
+    {% set name %}{{ study }}_{{ file.assayCode }}{% endset %}
+  {% endif %}
+  {% do file.update({'name': name}) %}
 
-    {% if name not in normSamples %}
-        {% do normSamples.update({name: {}}) %}
-        {% do normSamples[name].update(file) %}
-    {% endif %}
+  {% if name not in normSamples %}
+    {% do normSamples.update({name: {}}) %}
+    {% do normSamples[name].update(file) %}
+  {% endif %}
 {% endfor %}
 {% endif %}
 
 {%- for sample in samples.values() if sample.gltype in ('exome', 'genome') and sample.subGroup|lower == 'constitutional' %}
-    {% for normal in normSamples.values() if normal.assayCode == sample.assayCode %}
-        {% set name %}{{ normal.name }}{% endset %}
-        {% if name not in pairedNormSamples %}
-            {% do pairedNormSamples.update({name: {}}) %}
-            {% do pairedNormSamples[name].update(normal) %}
-            {{- prepare_tumor_only(normal) }}
-        {% endif %}
-    {% endfor %}
+  {% for normal in normSamples.values() if normal.assayCode == sample.assayCode %}
+    {% set name %}{{ normal.name }}{% endset %}
+    {% if name not in pairedNormSamples %}
+      {% do pairedNormSamples.update({name: {}}) %}
+      {% do pairedNormSamples[name].update(normal) %}
+      {{- prepare_tumor_only(normal) }}
+    {% endif %}
+  {% endfor %}
 {% endfor %}
 
 {%- for sample in samples.values() if sample.gltype in ('exome', 'genome') %}
 
-    {% if not sample.aligners | length >= 1 %}
-      {{- sample_aligners_did_not_traverse_to_module }}
-    {% endif %}
+  {% if not sample.aligners | length >= 1 %}
+    {{- sample_aligners_did_not_traverse_to_module }}
+  {% endif %}
 
-    {% for aligner in sample.aligners %}
+  {% for aligner in sample.aligners %}
 
     {% if sample.gltype in 'exome' %}
-        {% set taskPrefix = 'Exome' %}
-        
-        {%- if sample.subGroup|lower != 'tumor' %}
-            {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_chip_mutect2"]|default(false) %}
-                {{- chip_mutect2(sample, aligner, taskPrefix=taskPrefix) }}
-            {% endif %}
-        {% endif %}
-    {% elif sample.gltype in 'genome' %}
-        {% set taskPrefix = 'Genome' %}
+      {% set taskPrefix = 'Exome' %}
 
-        {% if tasks.Genome_constitutional_cna_caller_ichor|default(false) %}
-           {{- ichorcna(sample, aligner, taskPrefix=taskPrefix) }}
+      {%- if sample.subGroup|lower != 'tumor' %}
+        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_chip_mutect2"]|default(false) %}
+          {{- chip_mutect2(sample, aligner, taskPrefix=taskPrefix) }}
         {% endif %}
+      {% endif %}
+    {% elif sample.gltype in 'genome' %}
+      {% set taskPrefix = 'Genome' %}
+
+      {% if tasks.Genome_constitutional_cna_caller_ichor|default(false) %}
+        {{- ichorcna(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
     {% endif %}
 
     {%- if sample.subGroup|lower != 'tumor' %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_gatk_HaplotypeCaller"]|default(false) %}
-            {{- haplotypecallergvcf(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_deepvariant"]|default(false) %}
-            {{- deepvariant(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_freebayes"]|default(false) %}
-            {{- freebayes(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_genotype_hc_gvcf_gatk_GenotypeGVCFs"]|default(false) %}
-            {{- genotypegvcf(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_strelka2"]|default(false) %}
-            {{- strelka2_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_octopus"]|default(false) %}
-            {{- octopus_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_vardict"]|default(false) %}
-            {{- vardict_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_structural_caller_manta"]|default(false) %}
-            {{- manta_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
-        {% endif %}
-        {% if tasks[taskPrefix+"_constitutional_structural_caller_expansion_hunter"]|default(false) %}
-           {{- expansion_hunter(sample, aligner) }}
-        {% endif %}
-        {%- if tasks[taskPrefix+"_constitutional_cna_caller_gatk"]|default(false) %}
-            {% for normal in normSamples.values() if normal.assayCode == sample.assayCode and normal.gatkCnvPon is defined %}
-                {{- gatk_cnv_constitutional(sample, normal, aligner) }}
-            {% endfor %}
-        {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_gatk_HaplotypeCaller"]|default(false) %}
+        {{- haplotypecallergvcf(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_deepvariant"]|default(false) %}
+        {{- deepvariant(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_freebayes"]|default(false) %}
+        {{- freebayes(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_genotype_hc_gvcf_gatk_GenotypeGVCFs"]|default(false) %}
+        {{- genotypegvcf(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_strelka2"]|default(false) %}
+        {{- strelka2_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_octopus"]|default(false) %}
+        {{- octopus_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_snp_indel_caller_vardict"]|default(false) %}
+        {{- vardict_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_structural_caller_manta"]|default(false) %}
+        {{- manta_constitutional(sample, aligner, taskPrefix=taskPrefix) }}
+      {% endif %}
+      {% if tasks[taskPrefix+"_constitutional_structural_caller_expansion_hunter"]|default(false) %}
+        {{- expansion_hunter(sample, aligner) }}
+      {% endif %}
+      {%- if tasks[taskPrefix+"_constitutional_cna_caller_gatk"]|default(false) %}
+        {% set normal = normSamples|selectattr('assayCode', 'eq', sample.assayCode)|first %}
+        {% if normal and normal.gatkCnvPon is defined %}
+          {{- gatk_cnv_constitutional(sample, normal, aligner) }}
+        {% endfor %}
+      {% endif %}
     {% endif %}
 
-    {% endfor %}
+  {% endfor %}
 
 {% endfor %}
 {% endmacro %}

--- a/modules/dna_alignment/bwa_mem2_samtools.j2
+++ b/modules/dna_alignment/bwa_mem2_samtools.j2
@@ -111,7 +111,7 @@
   {% endfor %}
   output: {{ temp_dir }}/{{ sample.name }}_{{ rglb }}.{{ aligner }}.bam
   walltime: "24:00:00"
-  cpus: 16
+  cpus: 4
   mem: 8G
   queue_preset: "DEFAULT"
   container: {{ constants.tools.bwa_mem2_samtools.container }}
@@ -126,7 +126,7 @@
       -l INT       Compression level, from 0 to 9 [-1]
     #}
     samtools merge \
-      --threads 16 \
+      --threads 4 \
       -c \
       -f \
       -u \
@@ -151,6 +151,9 @@
       {% endif %}
       {% endfor %}
 
+{% set totalReads = rg|sum(attribute='numberOfReads') %}
+{% set read_bins = [0, 500000000, 1000000000, 2000000000, 4000000000, 8000000000] %}
+{% set memory_bins = ['16G','32G','48G','64G','80G'] %}
 
 - name: samtools_markdup_{{ sample.name }}_{{ rglb }}_{{ aligner }}
   tags: [{{ sample.gltype }}, alignment, mark_duplicates, samtools, {{ sample.name }}]
@@ -165,8 +168,8 @@
     {% endif %}
     - {{ results_dir }}/stats/{{ sample.name }}_{{ rglb }}.{{ aligner }}.bam.samtools.markdup.json
   walltime: "96:00:00"
-  cpus: 20
-  mem: 20G
+  cpus: 4
+  mem: {{ totalReads|assignbin(read_bins, memory_bins) }}
   queue_preset: "DEFAULT-LONG"
   container: {{ constants.tools.bwa_mem2_samtools.container }}
   digest: {{ constants.tools.bwa_mem2_samtools.digest }}
@@ -202,7 +205,7 @@
       -d {{ opt_dup_distance }} \
       -S \
       -f {{ results_dir }}/stats/{{ sample.name }}_{{ rglb }}.{{ aligner }}.bam.samtools.markdup.json \
-      --threads 20 \
+      --threads 4 \
       --write-index \
       -T {{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rglb }} \
       {{ temp_dir }}/{{ sample.name }}_{{ rglb }}.{{ aligner }}.bam \
@@ -224,7 +227,7 @@
   {% endfor %}
   output: {{ temp_dir }}/{{ sample.name }}.{{ aligner }}.md.bam
   walltime: "24:00:00"
-  cpus: 16
+  cpus: 4
   mem: 8G
   queue_preset: "DEFAULT"
   container: {{ constants.tools.bwa_mem2_samtools.container }}
@@ -238,7 +241,7 @@
       -f           Overwrite the output BAM if exist
     #}
     samtools merge \
-      --threads 16 \
+      --threads 4 \
       -c \
       -f \
       --write-index \

--- a/modules/dna_alignment/fgbio_umi.j2
+++ b/modules/dna_alignment/fgbio_umi.j2
@@ -364,7 +364,7 @@ other weird filters are in place
   {% endfor %}
   output: {{ temp_dir }}/{{ sample.name }}.{{ aligner }}.md.bam
   walltime: "24:00:00"
-  cpus: 16
+  cpus: 4
   mem: 8G
   queue_preset: "DEFAULT"
   container: {{ constants.tools.bwa_mem2_samtools.container }}
@@ -378,7 +378,7 @@ other weird filters are in place
       -f           Overwrite the output BAM if exist
     #}
     samtools merge \
-      --threads 16 \
+      --threads 4 \
       -c \
       -f \
       --write-index \

--- a/modules/qc/stats2lims.j2
+++ b/modules/qc/stats2lims.j2
@@ -7,7 +7,11 @@
 
 - name: stats2lims_{{ task }}_{{ file_type }}
   tags: [{{ tag1 }}, quality_control, stats, stats2lims, {{ tag2 }}]
-  input: {{ input_file }}
+  input:
+    - {{ input_file }}
+    {% if lims_cert is defined %}
+    - {{ lims_cert }}
+    {% endif %}
   walltime: "0:10:00"
   cpus: 1
   mem: 2G
@@ -23,6 +27,12 @@
     python3 {{ required_scripts.stats2lims.path }} \
       {% if file_type == "samtools_idxstats" %}
       --contigList "{{ constants.tempe.lims_contigs | replace(" ", "") }}" \
+      {% endif %}
+      {% if lims_url is defined %}
+      --url "{{ lims_url }}" \
+      {% endif %}
+      {% if lims_cert is defined %}
+      --cert "{{ lims_cert }}" \
       {% endif %}
       {{ input_file }} \
       {{ file_type }} \

--- a/modules/tumor_only/deepvariant.j2
+++ b/modules/tumor_only/deepvariant.j2
@@ -124,6 +124,7 @@
     postprocess_variants \
         --ref "{{ constants.tempe.reference_fasta }}" \
         --infile "{{ sample.name }}.cvo.tfrecord.gz" \
+        --novcf_stats_report \
         --outfile "${PROJECT_ROOT}/{{ all_vcf }}" \
         --nonvariant_site_tfrecord_path "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.gvcf.tfrecord@{{ nshards }}.gz" \
         --gvcf_outfile "${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}.{{ aligner }}.deepvariant.all.g.vcf.gz"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -130,8 +130,8 @@ constants:
       container: quay.io/biocontainers/vardict-java:1.8.3--hdfd78af_0
       digest: 4069c082c97470bce4a07f228dbf74b6ea3fc5c4eaa93ba76d2826a496ca3c44
     vcfmerger:
-      container: ghcr.io/tgen/containers/vcfmerger2:0.9.4-23080809
-      digest: 238a5ba82dbe2d55c94c5d98471e81e24c819afcb3a430014cde43e2fb8e46b0
+      container: artifactory.tgen.org/hpc-virtual-containers/oci/testing/vcfmerger2:0.9.5-23090516
+      digest: f4a829a9c4bf770147de8a114d1df8f8fa6e2931b8058a89ebeb1ad6db36a658
     vcf2maf:
       container: quay.io/biocontainers/vcf2maf:1.6.21--hdfd78af_0
       digest: e33def318468ac924bdcc280c4aa8984865709d111cd0df9b0d82c7908b7dd07

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -130,8 +130,8 @@ constants:
       container: quay.io/biocontainers/vardict-java:1.8.3--hdfd78af_0
       digest: 4069c082c97470bce4a07f228dbf74b6ea3fc5c4eaa93ba76d2826a496ca3c44
     vcfmerger:
-      container: artifactory.tgen.org/hpc-virtual-containers/oci/testing/vcfmerger2:0.9.5-23090516
-      digest: f4a829a9c4bf770147de8a114d1df8f8fa6e2931b8058a89ebeb1ad6db36a658
+      container: ghcr.io/tgen/containers/vcfmerger2:0.9.5-23090712
+      digest: 37640beed1f829702dbd8c03a1e4955a205abd8a38e209ea88ffa815c570a8fa
     vcf2maf:
       container: quay.io/biocontainers/vcf2maf:1.6.21--hdfd78af_0
       digest: e33def318468ac924bdcc280c4aa8984865709d111cd0df9b0d82c7908b7dd07

--- a/release_notes/v1.2.0.md
+++ b/release_notes/v1.2.0.md
@@ -1,0 +1,33 @@
+# Feature Release  
+Major changes (Changes that cause restarts are in bold):
+- ### All containers have been updated to use a more optimimally sized image, or using the image provided by the authors
+  - We changed base containers over to debian instead of a heavy rockylinux base, also moved to multi-stage builds
+- **Tool updates for bcftools, samtools, htslib, deepvariant, GATK, ichorCNA, sigprofiler, vardict**
+- We have added support for user supplied variables for the variant filtering tasks
+- New tools added:
+  - CNVear
+  - b_pure
+- Added PCR Free workflow https://github.com/tgen/tempe/issues/15
+- Since alignment must restart, https://github.com/tgen/tempe/issues/17 is handled
+- Adjusted support for fasterq files https://github.com/tgen/tempe/issues/24
+  - Petagene is only loaded for the copy fastq step and is decompressing the fasterq as part of the copy operation
+- Multiple UMI aware alignment updates https://github.com/tgen/tempe/issues/25 https://github.com/tgen/tempe/issues/26 https://github.com/tgen/tempe/issues/27 https://github.com/tgen/tempe/issues/36 https://github.com/tgen/tempe/issues/37
+- Adjusted memory usage for a couple of workflows including lancet and deepvariant https://github.com/tgen/tempe/issues/33
+  - Deepvariant is using an example of memory request based on the numberOfReads in the sample, this is planned to be expanded upon
+- Removed workflows that are outdated/superseded by newer tools:
+  - snpEff
+  - singleCellRNA support tasks (these will be broken into a separate pipeline in order to reduce workflow complexity)
+  - lumosVar
+  - CHIP/CutRun alignment and processing
+
+This update will cause all tasks to restart based on the container changes, and we apologize for the inconvenience, it is technically possible to avoid this if jetstream is told 
+to not include the container and digest as part of the task identity, rerender the workflow, and set tasks back to their previous state. Then mash the workflow with the new tempe
+version. A lot of tasks will still restart as a result of this, but you might be able to avoid restarting back to the alignment steps. This operation is not recommended, but feel
+free to contact bturner@tgen.org for assistance if this is required for your work.
+
+**Full Changelog**: https://github.com/tgen/tempe/compare/v1.1.2...v1.2.0
+
+---
+
+**You must use Jetstream v1.7.3+ in order to run this pipeline**  
+This is due to some additional template functions that have been added to the pipeline, namely an md5 function to render the md5sum of a file at render time, and assignBins, which is used to create and assign user defined bins.

--- a/required_scripts/uploadStats2Lims.py
+++ b/required_scripts/uploadStats2Lims.py
@@ -248,7 +248,7 @@ parser = argparse.ArgumentParser(description="Module used to push sample QC stat
                                              " with samStats2json output files", epilog=description(fileTypes),
                                  formatter_class=argparse.RawTextHelpFormatter)
 
-parser.add_argument('jsonfile', metavar="StatFile", help='path to the json that will be pushed to the LIMS')
+parser.add_argument('jsonfile', metavar='StatFile', help='path to the json that will be pushed to the LIMS')
 
 parser.add_argument('filetype', metavar='FileType', choices=fileTypes,
                     help='the file type that will be imported')
@@ -260,7 +260,11 @@ parser.add_argument('project', metavar='Project',  help='patient ID')
 
 parser.add_argument('study', metavar='Study',  help='name of the study (project)')
 
-parser.add_argument('-L', "--libraryID", metavar='LibraryID', help='name of the libraryID')
+parser.add_argument('-u', '--url', metavar='LIMS_url', default='https://tgen-fmp3.ad.tgen.org/fmi/data/v1/databases/KBase_V2', help='url of the LIMS instance')
+
+parser.add_argument('-C', '--cert', metavar='/path/to/CA.cer', default='/packages/python/3.6.0/share/TGenCA.cer', help='path to the KBase CA certificate')
+
+parser.add_argument('-L', '--libraryID', metavar='LibraryID', help='name of the libraryID')
 
 parser.add_argument('-c', '--contigList', metavar='STR', default='None', type=str,
                     help='comma separated list of contigs to push into the LIMS . (=\'None\')')
@@ -275,13 +279,14 @@ args = parser.parse_args()
 contig_list = args.contigList.split(',')
 
 # Required cert for the TGen LIMS
-CA = "/packages/python/3.6.0/share/TGenCA.cer"
+CA = args.cert
+URL = args.url
 
 # Set REST api https paths used on the private TGen network
-urlStart = "https://tgen-fmp3.ad.tgen.org/fmi/data/v1/databases/KBase_V2/sessions"
-urlFind = "https://tgen-fmp3.ad.tgen.org/fmi/data/v1/databases/KBase_V2/layouts/SamplesSequencing_REST/_find"
-urlFind2 = "https://tgen-fmp3.ad.tgen.org/fmi/data/v1/databases/KBase_V2/layouts/DCLStudies_REST/_find"
-urlPatch = "https://tgen-fmp3.ad.tgen.org/fmi/data/v1/databases/KBase_V2/layouts/SamplesSequencing_REST/records/"
+urlStart = f"{URL}/sessions"
+urlFind = f"{URL}/layouts/SamplesSequencing_REST/_find"
+urlFind2 = f"{URL}/layouts/DCLStudies_REST/_find"
+urlPatch = f"{URL}/layouts/SamplesSequencing_REST/records/"
 
 userName = None
 


### PR DESCRIPTION
This includes some adjustments needed before the v1.2.0 release:
- Fixing cpu and memory requests for alignment workflows
- deepvariant postprocess_variants will skip report generation since there is potential for an edge case long runtime bug
  - This report has not been used internally, but end users were attempting to use this file and led to confusion
- Fixed chip_mutect2 PON usage, it was always going to use 1000g PON before
- vcfMerger2 has been bumped to 0.9.5 with fixes for strelka prep (phaser) handling
- stats2lims has been updated to use externally defined url and certificate locations in anticipation of cluster migration