### PR TITLE
Added support for external ichorCNA pon

### DIFF
--- a/modules/constitutional/ichorcna.j2
+++ b/modules/constitutional/ichorcna.j2
@@ -149,7 +149,11 @@
             gcWig = "${EXTDATA}/gc_hg38_1000kb.wig", 
             mapWig = "${EXTDATA}/map_hg38_1000kb.wig", 
             repTimeWig = NULL, 
-            normal_panel=NULL, 
+            {% if control.ichorPon is defined %}
+            normal_panel="temp/tumor_only/control_data_files/{{ control.assayCode }}/{{ control.ichorPon | basename }}",
+            {% else %}
+            normal_panel=NULL,
+            {% endif %}
             sex = NULL, 
             exons.bed=NULL, 
             id = "{{ sample.name}}.{{ aligner }}.ichorCNA", 


### PR DESCRIPTION
We were hardcoded to NULL before, this allows for the use of a PON defined in the controlDataFiles