### PR TITLE
Bumping to deepvariant v1.6.0

### DIFF
--- a/modules/constitutional/deepvariant.j2
+++ b/modules/constitutional/deepvariant.j2
@@ -54,7 +54,7 @@
       --reads "${PROJECT_ROOT}/{{ bam }}" \
       --examples "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.ex.tfrecord@{{ nshards }}.gz" \
       --gvcf "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.gvcf.tfrecord@{{ nshards }}.gz"
-      
+
 {% endfor %}
 
 - name: deepvariant_call_variants_{{ sample.name }}_{{ aligner }}
@@ -85,9 +85,9 @@
     {# Run call_variants #}
     call_variants \
       {% if sample.gltype == 'exome' %}
-      --checkpoint /opt/models/wes/model.ckpt \
+      --checkpoint /opt/models/wes \
       {% else %}
-      --checkpoint /opt/models/wgs/model.ckpt \
+      --checkpoint /opt/models/wgs \
       {% endif %}
       --examples "{{ sample.name }}.ex.tfrecord@{{ nshards }}.gz" \
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
@@ -115,11 +115,11 @@
     set -o pipefail
 
     PROJECT_ROOT=$PWD
-    
+
     mkdir -p "{{ results_dir }}"
 
     cd "{{ temp_dir }}"
-    
+
     {# Run postprocess_variants with gVCFs #}
     postprocess_variants \
         --ref "{{ constants.tempe.reference_fasta }}" \

--- a/modules/constitutional/deepvariant.j2
+++ b/modules/constitutional/deepvariant.j2
@@ -93,7 +93,7 @@
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
 
 {% set read_bins = [0, 500000000, 1000000000, 2000000000, 4000000000, 8000000000] %}
-{% set memory_bins = ['16G','24G','32G','40G','48G'] %}
+{% set memory_bins = ['32G','40G','48G','56G','64G'] %}
 
 - name: deepvariant_postprocess_variants_{{ sample.name }}_{{ aligner }}
   tags: [{{ sample.gltype}}, constitutional, snp_indel_caller, deepvariant, {{ sample.name }}]
@@ -104,7 +104,7 @@
   output:
     - {{ all_vcf }}
     - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.deepvariant.all.g.vcf.gz
-  cpus: 1
+  cpus: 4
   mem: {{ sample.total_reads|assignbin(read_bins, memory_bins) }}
   walltime: "24:00:00"
   queue_preset: "DEFAULT"
@@ -122,6 +122,7 @@
 
     {# Run postprocess_variants with gVCFs #}
     postprocess_variants \
+        --cpus 4 \
         --ref "{{ constants.tempe.reference_fasta }}" \
         --infile "{{ sample.name }}.cvo.tfrecord.gz" \
         --outfile "${PROJECT_ROOT}/{{ all_vcf }}" \

--- a/modules/tumor_only/deepvariant.j2
+++ b/modules/tumor_only/deepvariant.j2
@@ -54,7 +54,7 @@
       --reads "${PROJECT_ROOT}/{{ bam }}" \
       --examples "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.ex.tfrecord@{{ nshards }}.gz" \
       --gvcf "${PROJECT_ROOT}/{{ temp_dir }}/{{ sample.name }}.gvcf.tfrecord@{{ nshards }}.gz"
-      
+
 {% endfor %}
 
 - name: tumor_only_deepvariant_call_variants_{{ sample.name }}_{{ aligner }}
@@ -85,9 +85,9 @@
     {# Run call_variants #}
     call_variants \
       {% if sample.gltype == 'exome' %}
-      --checkpoint /opt/models/wes/model.ckpt \
+      --checkpoint /opt/models/wes \
       {% else %}
-      --checkpoint /opt/models/wgs/model.ckpt \
+      --checkpoint /opt/models/wgs \
       {% endif %}
       --examples "{{ sample.name }}.ex.tfrecord@{{ nshards }}.gz" \
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
@@ -115,11 +115,11 @@
     set -o pipefail
 
     PROJECT_ROOT=$PWD
-    
+
     mkdir -p "{{ results_dir }}"
 
     cd "{{ temp_dir }}"
-    
+
     {# Run postprocess_variants with gVCFs #}
     postprocess_variants \
         --ref "{{ constants.tempe.reference_fasta }}" \

--- a/modules/tumor_only/deepvariant.j2
+++ b/modules/tumor_only/deepvariant.j2
@@ -93,7 +93,7 @@
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
 
 {% set read_bins = [0, 500000000, 1000000000, 2000000000, 4000000000, 8000000000] %}
-{% set memory_bins = ['16G','24G','32G','40G','48G'] %}
+{% set memory_bins = ['32G','40G','48G','56G','64G'] %}
 
 - name: tumor_only_deepvariant_postprocess_variants_{{ sample.name }}_{{ aligner }}
   tags: [{{ sample.gltype}}, tumor_only, snp_indel_caller, deepvariant, {{ sample.name }}]
@@ -104,7 +104,7 @@
   output:
     - {{ all_vcf }}
     - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.deepvariant.all.g.vcf.gz
-  cpus: 1
+  cpus: 4
   mem: {{ sample.total_reads|assignbin(read_bins, memory_bins) }}
   walltime: "24:00:00"
   queue_preset: "DEFAULT"
@@ -122,6 +122,7 @@
 
     {# Run postprocess_variants with gVCFs #}
     postprocess_variants \
+        --cpus 4 \
         --ref "{{ constants.tempe.reference_fasta }}" \
         --infile "{{ sample.name }}.cvo.tfrecord.gz" \
         --novcf_stats_report \

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -25,8 +25,8 @@ constants:
       container: ghcr.io/tgen/containers/cnvear:0.1.7
       digest: 4a857e23b484ed0c32de5fb9356d427cd52ea141a797d443f453c457ab852ad2
     deepvariant:
-      container: google/deepvariant:1.5.0-gpu
-      digest: 312af65c01d27e4fc8bb34a4c933ca708bd24d2e7d8ac3076c9c7c078afa20e9
+      container: google/deepvariant:1.6.0-gpu
+      digest: 3b11b08770e4c2818fa65195b31267a430aac815652a7fc4bcd3a0e284a5368f
     dle:
       container: ghcr.io/tgen/containers/discordant_loci_extractor:0.1.5-23080815
       digest: 0a5b010298b97573114936c1bf8ae0c319ec0b84818eb14917f8161e4826b927


### PR DESCRIPTION
This bumps deepvariant to use the v1.6.0 release, a notable change is the path to the checkpoint model now is just the parent dir (this appears to be the same method deepvariant uses internally with the `run_deepvariant.py` script).

Additionally, postprocess_variants needed more memory in testing, so the memory bins have been shifted. But postprocess_variants now supports `--cpus` for multithreading. We have set this to 4 to help with cpu+memory packing.