### PR TITLE
Reverting to using ${JS_PIPELINE_PATH} as this avoids erroneous task identity changes between storage locations

### DIFF
--- a/main.j2
+++ b/main.j2
@@ -46,7 +46,7 @@
 
 {% set required_scripts = {} %}
 {% for name, value in constants.tempe.required_scripts.items() %}
-    {% set path = __pipeline__.path ~ '/' ~ __pipeline__.bin ~ value %}
+    {% set path = '${JS_PIPELINE_PATH}/' ~ __pipeline__.bin ~ value %}
     {% do required_scripts.update({name: {}}) %}
     {% do required_scripts[name].update({"path": path}) %}
 {% endfor %}


### PR DESCRIPTION
Reverting to using ${JS_PIPELINE_PATH} as this avoids erroneous task identity changes between storage locations. 

E.g. certain tasks were triggered to restart if running under a different pipeline path than the previous run, this would pop up between version changes and whenever a different user attempts to run the pipeline from the same project.

This works best with Jetstream updates from https://github.com/tgen/jetstream/commit/e9dd199dad04662e47230819f29c0f34a131b001 which will be released with Jetstream v1.7.4. As this release will automatically bind the ${JS_PIPELINE_PATH} if it exists in the environment. 

As a reminder, Jetstream sets ${JS_PIPELINE_PATH} for us during invocations of `jetstream pipelines` and `jetstream run --pipeline`. If running Tempe with an older version of Jetstream, then it is recommended to set `SINGULARITYENV_JS_PIPELINE_PATH` to the install path of Tempe and append this path to `SINGULARITY_BIND` - this ensures that the environment variable is carried in and ensures that the path is bound by singularity.