### PR TITLE
Improving task control syntax for snpsniffer and RNA tasks

### DIFF
--- a/main.j2
+++ b/main.j2
@@ -136,7 +136,7 @@
 
     {% if sample.gltype in 'rna' %}
         {# default to adding star as aligner until we have more than one aligner #}
-        {% if tasks.RNA_alignment_rna_alignment_STAR|default(true) %}
+        {% if tasks['RNA_alignment_rna_alignment_STAR']|default(true) %}
             {% do sample.aligners.append('star') %}
         {% endif %}
     {% endif %}
@@ -183,7 +183,7 @@
 
 {# project level quality control #}
 {% if samples|length > 1 %}
-  {% if (tasks.Exome_quality_control_genotype_concordance_snpSniffer or tasks.Genome_quality_control_genotype_concordance_snpSniffer) |default(false) %}
+  {% if tasks['Exome_quality_control_genotype_concordance_snpSniffer']|default(true) or tasks['Genome_quality_control_genotype_concordance_snpSniffer']|default(true) %}
     {{- snpsniffer_summary(samples) }}
   {% endif %}
 {% endif %}

--- a/modules/constitutional/main.j2
+++ b/modules/constitutional/main.j2
@@ -67,7 +67,7 @@
     {% elif sample.gltype in 'genome' %}
       {% set taskPrefix = 'Genome' %}
 
-      {% if tasks.Genome_constitutional_cna_caller_ichor|default(false) %}
+      {% if tasks['Genome_constitutional_cna_caller_ichor']|default(false) %}
         {{- ichorcna(sample, aligner, taskPrefix=taskPrefix) }}
       {% endif %}
     {% endif %}

--- a/modules/qc/bam_qc_all.j2
+++ b/modules/qc/bam_qc_all.j2
@@ -648,7 +648,7 @@
 
 
 {% macro bam_qc_snpsniffer_geno(sample, libraryCount, sample_lb, taskPrefix=taskPrefix, aligner=aligner, bam_level=true) %}
-{% if tasks[taskPrefix+"_quality_control_genotype_concordance_snpSniffer"]|default(false) %}
+{% if tasks[taskPrefix+"_quality_control_genotype_concordance_snpSniffer"]|default(true) %}
 
   {% set results_dir %}{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/stats{% endset %}
 

--- a/modules/qc/bam_qc_rna.j2
+++ b/modules/qc/bam_qc_rna.j2
@@ -74,7 +74,7 @@
 {% endmacro %}
 
 {% macro bam_qc_rna_BTcell_loci(sample, libraryCount, sample_lb, taskPrefix=taskPrefix, aligner='star', bam_level=true) %}
-{% if tasks.RNA_quality_control_stats_samtools_bedcov|default(false) %}
+{% if tasks['RNA_quality_control_stats_samtools_bedcov']|default(false) %}
 
   {% set results_dir %}{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/stats{% endset %}
 

--- a/modules/rna/main.j2
+++ b/modules/rna/main.j2
@@ -16,13 +16,13 @@
       {% set opt_dup_distance = 100 %}
     {% endif %}
 
-    {% if tasks.RNA_transcriptome_quantify_expression_salmon_fastqs|default(false) %}
+    {% if tasks['RNA_transcriptome_quantify_expression_salmon_fastqs']|default(false) %}
       {% set task %}salmon_quant_cdna_{{ sample.name }}{% endset %}
       {% do task_list.append(task) %}
       {{- salmon(sample) }}
     {% endif %}
 
-    {# in main we check {% if tasks.RNA_alignment_rna_alignment_STAR|default(false) %} #}
+    {# in main we check {% if tasks['RNA_alignment_rna_alignment_STAR']|default(false) %} #}
     {% if 'star' in sample.aligners %}
       {% set task %}star_quant_{{ sample.name }}{% endset %}
       {% do task_list.append(task) %}
@@ -31,7 +31,7 @@
       {{- bam_qc(sample, aligner='star') }}
     {% endif %}
 
-    {% if tasks.RNA_transcriptome_fusion_caller_STAR_Fusion|default(false) %}
+    {% if tasks['RNA_transcriptome_fusion_caller_STAR_Fusion']|default(false) %}
       {% set task %}star_fusion_alignment_{{ sample.name }}{% endset %}
       {% do task_list.append(task) %}
       {% set task %}star_fusion_{{ sample.name }}{% endset %}

--- a/modules/rna/star_fusion.j2
+++ b/modules/rna/star_fusion.j2
@@ -38,7 +38,7 @@
     - {{ constants.tempe.starfusion_index }}
   output:
     - {{ results_dir }}/{{ sample.name }}_Chimeric.out.junction
-    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
+    {% if tasks['RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM']|default(false) %}
     - {{ results_dir }}/{{ sample.name }}_starfusion.bam
     - {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
     {% endif %}
@@ -107,7 +107,7 @@
 
     samtools index -@ 20 {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam
 
-    {% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
+    {% if tasks['RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM']|default(false) %}
     mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam {{ results_dir }}/{{ sample.name }}_starfusion.bam
     mv {{ temp_dir }}/{{ sample.name }}.Aligned.sorted.bam.bai {{ results_dir }}/{{ sample.name }}_starfusion.bam.bai
     {% endif %}
@@ -234,7 +234,7 @@
         mv FusionInspector-inspect/fi_workdir/trinity_GG/Trinity-GG.fasta ${PROJECT_ROOT}/{{ results_dir }}/{{ sample.name }}_Trinity-GG.fasta
     fi
 
-{% if tasks.RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM|default(false) %}
+{% if tasks['RNA_transcriptome_fusion_caller_Keep_STAR_Fusion_BAM']|default(false) %}
 {% if cram|default(true) %}
 {% set bam_path %}{{ results_dir }}/{{ sample.name }}_starfusion.bam{% endset %}
 {% set cram_path %}{{ results_dir }}/{{ sample.name }}_starfusion.cram{% endset %}

--- a/modules/rna/star_quant.j2
+++ b/modules/rna/star_quant.j2
@@ -278,7 +278,7 @@
 
 {% set task_list = [] %}
 
-{% if tasks.RNA_transcriptome_quantify_expression_subread_featureCounts|default(false) %}
+{% if tasks['RNA_transcriptome_quantify_expression_subread_featureCounts']|default(false) %}
   {% set task %}featurecounts_{{ sample.name }}{% endset %}
   {% do task_list.append(task) %}
   {{- featurecounts(sample) }}


### PR DESCRIPTION
Improving task control syntax by using task['task_name']|default() instead of task.task_name|default() as this handles existence checks. This is relevant for cases where the task list has not been defined - or if the specific task variable we are checking for does not exist.

We also now enable snpsniffer by default, since alignment is enabled by default if no tasks are defined.