### PR TITLE
Fixing 1.2.1 nuisances

### DIFF
--- a/modules/annotation/bcftools_annotate.j2
+++ b/modules/annotation/bcftools_annotate.j2
@@ -4,10 +4,8 @@
 
 - name: bcftools_annotate_{{ variant_caller }}_{{ sample_or_pair.name }}_{{ aligner }}
   tags: [{{ sample_or_pair.gltype }}, {{ analysis_type }}, annotate_vcfs, {{ variant_caller }}, {{ sample_or_pair.name }}]
-  input: {{ input_vcf }}
-  output:
-    - {{ output_vcf }}
-    - {{ output_vcf }}.tbi
+  input:
+    - {{ input_vcf }}
     {% if tasks[taskPrefix+"_"+analysis_type+"_annotate_vcfs_bcftools_dbsnp"]|default(false) %}
     - {{ constants.tempe.dbsnp }}
     {% endif %}
@@ -29,6 +27,9 @@
     {% if tasks[taskPrefix+"_"+analysis_type+"_annotate_vcfs_bcftools_topmed"]|default(false) %}
     - {{ constants.tempe.topmed }}
     {% endif %}
+  output:
+    - {{ output_vcf }}
+    - {{ output_vcf }}.tbi
   walltime: "8:00:00"
   cpus: 4
   mem: 4G

--- a/modules/constitutional/deepvariant.j2
+++ b/modules/constitutional/deepvariant.j2
@@ -93,7 +93,7 @@
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
 
 {% set read_bins = [0, 500000000, 1000000000, 2000000000, 4000000000, 8000000000] %}
-{% set memory_bins = ['32G','40G','48G','56G','64G'] %}
+{% set memory_bins = ['56G','64G','72G','80G','88G'] %}
 
 - name: deepvariant_postprocess_variants_{{ sample.name }}_{{ aligner }}
   tags: [{{ sample.gltype}}, constitutional, snp_indel_caller, deepvariant, {{ sample.name }}]

--- a/modules/constitutional/manta.j2
+++ b/modules/constitutional/manta.j2
@@ -80,9 +80,8 @@
 
     {# Remove the remaining files #}
     {% set task %}manta_{{ sample.name }}_{{ aligner }}{% endset %}
-    {% set before_task %}manta_filter_pass_{{ sample.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
-    {{- remove_files(directory, before_task, task) }}
+    {{- remove_files(directory, none, task) }}
 
 - name: manta_filter_pass_{{ sample.name }}_{{ aligner }}
   tags: [{{ sample.gltype}}, constitutional, structural_caller, manta, {{ sample.name }}]
@@ -90,8 +89,8 @@
     - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.vcf.gz
     - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.vcf.gz.tbi
   output:
-    - {{ temp_dir }}/results/variants/diploidSV.pass.vcf.gz
-    - {{ temp_dir }}/results/variants/diploidSV.pass.vcf.gz.tbi
+    - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass.vcf.gz
+    - {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass.vcf.gz.tbi
   cpus: 1
   mem: 2G
   walltime: "12:00:00"
@@ -109,12 +108,12 @@
     bcftools filter \
       -i 'FILTER == "PASS"' \
       -O z \
-      -o {{ temp_dir }}/results/variants/diploidSV.pass.vcf.gz \
+      -o {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass.vcf.gz \
       {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.vcf.gz
 
-    bcftools index --tbi --force {{ temp_dir }}/results/variants/diploidSV.pass.vcf.gz
+    bcftools index --tbi --force {{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass.vcf.gz
 
-{% set input_vcf %}{{ temp_dir }}/results/variants/diploidSV.pass.vcf.gz{% endset %}
+{% set input_vcf %}{{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass.vcf.gz{% endset %}
 {% set final_vcf_prefix %}{{ results_dir }}/{{ sample.name }}.{{ aligner }}.manta.diploidSV.pass{% endset %}
 {{- vep(sample, results_dir, input_vcf, 'manta', final_vcf_prefix, aligner, 'constitutional') }}
 

--- a/modules/tumor_only/deepvariant.j2
+++ b/modules/tumor_only/deepvariant.j2
@@ -93,7 +93,7 @@
       --outfile "{{ sample.name }}.cvo.tfrecord.gz"
 
 {% set read_bins = [0, 500000000, 1000000000, 2000000000, 4000000000, 8000000000] %}
-{% set memory_bins = ['32G','40G','48G','56G','64G'] %}
+{% set memory_bins = ['56G','64G','72G','80G','88G'] %}
 
 - name: tumor_only_deepvariant_postprocess_variants_{{ sample.name }}_{{ aligner }}
   tags: [{{ sample.gltype}}, tumor_only, snp_indel_caller, deepvariant, {{ sample.name }}]

--- a/modules/tumor_only/mm_igtx_calling.j2
+++ b/modules/tumor_only/mm_igtx_calling.j2
@@ -95,7 +95,7 @@
     - {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz
     - {{ temp_dir }}/igtx_gene_regions.bed
     - {{ temp_dir }}/igtx_regions.bed
-  walltime: "12:00:00"
+  walltime: "48:00:00"
   cpus: 4
   mem: 8G
   queue_preset: "DEFAULT"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2,7 +2,7 @@ __pipeline__:
   name: tempe
   main: main.j2
   description: Rapid Human GRCh38 genomics suite
-  version: v1.2.1
+  version: v1.2.2.dev1
   bin: required_scripts/
 constants:
   tools:


### PR DESCRIPTION
This fixes a small handful of bugs/nuisances that exist in the v1.2.1 release, main changes here are:
- Increasing memory for deepvariant
- Longer walltime for discordant_loci_extractor
- Added a results_dir level diploidSV.pass.vcf for constitutional manta, fixing some downstream processing issues
- Fixing the input to bcftools_annotate to include the annotation databases