### PR TITLE
Modifications to interval 4

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -597,8 +597,8 @@ constants:
       - - {"contig": "chr1", "length": 20338057, "start": 228608365, "stop": 248946422}
         - {"contig": "chr2", "length": 16135118, "start": 10001, "stop": 16145119}
         - {"contig": "chr2", "length": 16721010, "start": 16146120, "stop": 32867130}
-        - {"contig": "chr2", "length": 48494, "start": 32868131, "stop": 32916625}
-      - - {"contig": "chr2", "length": 56413053, "start": 32917626, "stop": 89330679}
+        - {"contig": "chr2", "length": 47169, "start": 32868131, "stop": 32915300}
+      - - {"contig": "chr2", "length": 56412279, "start": 32918400, "stop": 89330679}
         - {"contig": "chr2", "length": 155312, "start": 89530680, "stop": 89685992}
         - {"contig": "chr2", "length": 648518, "start": 89753993, "stop": 90402511}
         - {"contig": "chr2", "length": 735633, "start": 91402512, "stop": 92138145}
@@ -620,10 +620,8 @@ constants:
         - {"contig": "chr4", "length": 456438, "start": 8816478, "stop": 9272916}
         - {"contig": "chr4", "length": 22496378, "start": 9322917, "stop": 31819295}
         - {"contig": "chr4", "length": 1000446, "start": 31832570, "stop": 32833016}
-        - {"contig": "chr4", "length": 16497907, "start": 32839017, "stop": 49336924}
-        - {"contig": "chr4", "length": 171175, "start": 49486925, "stop": 49658100}
-        - {"contig": "chr4", "length": 2035850, "start": 49708101, "stop": 51743951}
-        - {"contig": "chr4", "length": 7084841, "start": 51793952, "stop": 58878793}
+        - {"contig": "chr4", "length": 16238183, "start": 32839017, "stop": 49077200}
+        - {"contig": "chr4", "length": 7062693, "start": 51816100, "stop": 58878793}
       - - {"contig": "chr4", "length": 131201739, "start": 58921382, "stop": 190123121}
       - - {"contig": "chr4", "length": 31433, "start": 190173122, "stop": 190204555}
         - {"contig": "chr5", "length": 17520547, "start": 10001, "stop": 17530548}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -597,8 +597,8 @@ constants:
       - - {"contig": "chr1", "length": 20338057, "start": 228608365, "stop": 248946422}
         - {"contig": "chr2", "length": 16135118, "start": 10001, "stop": 16145119}
         - {"contig": "chr2", "length": 16721010, "start": 16146120, "stop": 32867130}
-        - {"contig": "chr2", "length": 47169, "start": 32868131, "stop": 32915300}
-      - - {"contig": "chr2", "length": 56412279, "start": 32918400, "stop": 89330679}
+        - {"contig": "chr2", "length": 47170, "start": 32868131, "stop": 32915301}
+      - - {"contig": "chr2", "length": 56413053, "start": 32917626, "stop": 89330679}
         - {"contig": "chr2", "length": 155312, "start": 89530680, "stop": 89685992}
         - {"contig": "chr2", "length": 648518, "start": 89753993, "stop": 90402511}
         - {"contig": "chr2", "length": 735633, "start": 91402512, "stop": 92138145}
@@ -620,8 +620,10 @@ constants:
         - {"contig": "chr4", "length": 456438, "start": 8816478, "stop": 9272916}
         - {"contig": "chr4", "length": 22496378, "start": 9322917, "stop": 31819295}
         - {"contig": "chr4", "length": 1000446, "start": 31832570, "stop": 32833016}
-        - {"contig": "chr4", "length": 16238183, "start": 32839017, "stop": 49077200}
-        - {"contig": "chr4", "length": 7062693, "start": 51816100, "stop": 58878793}
+        - {"contig": "chr4", "length": 16497907, "start": 32839017, "stop": 49336924}
+        - {"contig": "chr4", "length": 171175, "start": 49486925, "stop": 49658100}
+        - {"contig": "chr4", "length": 2035850, "start": 49708101, "stop": 51743951}
+        - {"contig": "chr4", "length": 7084841, "start": 51793952, "stop": 58878793}
       - - {"contig": "chr4", "length": 131201739, "start": 58921382, "stop": 190123121}
       - - {"contig": "chr4", "length": 31433, "start": 190173122, "stop": 190204555}
         - {"contig": "chr5", "length": 17520547, "start": 10001, "stop": 17530548}


### PR DESCRIPTION
These regions overlap denylist regions and of which interval 4 overlaps LINC00486 (long intergenic non-protein coding RNA 486) which has a pileup region that spike coverage above 1 million (in recent sequencing data). Historically interval 4 has been problematic in terms of runtime for VarDict and causes octopus to segmentation fault (I wonder if octopus is actually leveraging the `--skip-regions-file` option.)

Additionally interval 11 has also been problematic, the region changed here overlaps a large portion of the centromere. I have found other cases of intervals that overlap large regions of the centromere, for example interval 13 contains many disjoint/broken regions that span over the centromere.

I will follow up with additional evidence, I think modifications to 4 and 11 should be made at a minimum. But I think it can also be argued that if we are changing intervals, then we should also remove other regions that can be considered as "irrelevant".