### PR TITLE
Additional check for if the READGROUPS object contains an object

### DIFF
--- a/required_scripts/uploadStats2Lims.py
+++ b/required_scripts/uploadStats2Lims.py
@@ -438,7 +438,8 @@ try:
                 else:
                     break
 
-            if len(contents["SAMPLES"][sample_counter]["LIBRARIES"][library_counter]["READGROUPS"][0]) > 0:
+            if len(contents["SAMPLES"][sample_counter]["LIBRARIES"][library_counter]["READGROUPS"]) > 0 and \
+                    len(contents["SAMPLES"][sample_counter]["LIBRARIES"][library_counter]["READGROUPS"][0]) > 0:
 
                 # Loop through each readgroup
                 readgroup_counter = 0


### PR DESCRIPTION
Additional check for if the READGROUPS object contains an object, this is needed by the snpsniffer json - this script has been tested on ~10 projects and appears to be a more complete implementation (should not require additional PRs)