### PR TITLE
Fix 1.2.1 nuisances

### DIFF
--- a/main.j2
+++ b/main.j2
@@ -183,7 +183,7 @@
 
 {# project level quality control #}
 {% if samples|length > 1 %}
-  {% if tasks['Exome_quality_control_genotype_concordance_snpSniffer']|default(true) or tasks['Genome_quality_control_genotype_concordance_snpSniffer']|default(true) %}
+  {% if tasks['Exome_quality_control_genotype_concordance_snpSniffer']|default(false) or tasks['Genome_quality_control_genotype_concordance_snpSniffer']|default(false) %}
     {{- snpsniffer_summary(samples) }}
   {% endif %}
 {% endif %}

--- a/modules/constitutional/manta.j2
+++ b/modules/constitutional/manta.j2
@@ -101,9 +101,6 @@
     set -eu
     set -o pipefail
 
-    {# Ensuring that the output dir exists for bcftools filter #}
-    mkdir -p {{ temp_dir }}/results/variants
-
     {# filtering somatic vcf by PASS #}
     bcftools filter \
       -i 'FILTER == "PASS"' \

--- a/modules/metrics/main.j2
+++ b/modules/metrics/main.j2
@@ -52,6 +52,10 @@
     {% endif %}
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'vep') }}
   {% endif %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_sigprofiler"]|default(false) and pair.normal.pathToBam is defined %}
+    {% set tumor_only_vcf_prefix %}{{ final_vcf_prefix }}.vep.pick.flt{% endset %}
+    {{- sigprofiler(pair, tumor_only_vcf_prefix, variant_caller, aligner) }}
+  {% endif %}
   {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(false) %}
     {% if tasks[taskPrefix+"_somatic_annotate_vcfs_bcftools_topmed"]|default(false) %}
     {% set final_vcf %}{{ final_vcf_prefix }}.vep.full.vcf.gz{% endset %}
@@ -64,8 +68,10 @@
   {{- msisensor_pro(pair, normal_bam, tumor_bam, aligner) }}
 {% endif %}
 
-{% if tasks[taskPrefix+"_somatic_sample_metric_sigprofiler"]|default(false) %}
-  {{- sigprofiler(pair, vcf_prefix, variant_caller, aligner) }}
+{% if pair.normal.pathToBam is not defined %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_sigprofiler"]|default(false) %}
+    {{- sigprofiler(pair, vcf_prefix, variant_caller, aligner) }}
+  {% endif %}
 {% endif %}
 
 {% endmacro %}

--- a/modules/qc/bam_qc_all.j2
+++ b/modules/qc/bam_qc_all.j2
@@ -648,7 +648,7 @@
 
 
 {% macro bam_qc_snpsniffer_geno(sample, libraryCount, sample_lb, taskPrefix=taskPrefix, aligner=aligner, bam_level=true) %}
-{% if tasks[taskPrefix+"_quality_control_genotype_concordance_snpSniffer"]|default(true) %}
+{% if tasks[taskPrefix+"_quality_control_genotype_concordance_snpSniffer"]|default(false) %}
 
   {% set results_dir %}{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/stats{% endset %}
 

--- a/modules/tumor_only/lancet.j2
+++ b/modules/tumor_only/lancet.j2
@@ -14,6 +14,7 @@
 {% for batch in constants.tempe.calling_intervals %}
 - name: tumor_only_lancet_{{ pair.name }}_{{ aligner }}_{{ loop.index }}
   tags: [{{ pair.gltype }}, tumor_only, snp_indel_caller, lancet, {{ pair.name }}]
+  reset: prepare_tumor_only_{{ pair.normal.name }}
   input:
     - {{ normal_bam }}
     - {{ normal_bam }}.bai

--- a/modules/tumor_only/manta.j2
+++ b/modules/tumor_only/manta.j2
@@ -11,6 +11,7 @@
 
 - name: tumor_only_manta_{{ pair.tumor.name }}_{{ aligner }}
   tags: [{{ pair.gltype }}, tumor_only, structural_caller, manta, {{ pair.tumor.name }}]
+  reset: prepare_tumor_only_{{ pair.normal.name }}
   input:
     - {{ normal_bam }}
     - {{ normal_bam }}.bai

--- a/modules/tumor_only/mutect2.j2
+++ b/modules/tumor_only/mutect2.j2
@@ -14,6 +14,7 @@
 {% for batch in constants.tempe.calling_intervals %}
 - name: tumor_only_mutect2_{{ pair.name }}_{{ aligner }}_{{ loop.index }}
   tags: [{{ pair.gltype }}, tumor_only, snp_indel_caller, gatk_mutect2, {{ pair.name }}]
+  reset: prepare_tumor_only_{{ pair.normal.name }}
   input:
     - {{ normal_bam }}
     - {{ normal_bam }}.bai

--- a/modules/tumor_only/octopus.j2
+++ b/modules/tumor_only/octopus.j2
@@ -14,6 +14,7 @@
 {% for batch in constants.tempe.primary_contig_calling_intervals %}
 - name: tumor_only_octopus_{{ pair.name }}_{{ aligner }}_{{ loop.index }}
   tags: [{{ pair.gltype }}, tumor_only, snp_indel_caller, octopus, {{ pair.name }}]
+  reset: prepare_tumor_only_{{ pair.normal.name }}
   input:
     - {{ normal_bam }}
     - {{ normal_bam }}.bai

--- a/modules/tumor_only/vardict.j2
+++ b/modules/tumor_only/vardict.j2
@@ -15,6 +15,7 @@
 {% for batch in constants.tempe.calling_intervals %}
 - name: tumor_only_vardict_makewindows_{{ pair.name }}_{{ aligner }}_{{ loop.index }}
   tags: [{{ pair.gltype }}, tumor_only, snp_indel_caller, VarDict, {{ pair.name }}]
+  reset: prepare_tumor_only_{{ pair.normal.name }}
   input:
     - {{ normal_bam }}
     - {{ normal_bam }}.bai

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1129,7 +1129,7 @@ constants:
       - - {"contig": "chr1", "length": 20338057, "start": 228608365, "stop": 248946422}
         - {"contig": "chr2", "length": 16135118, "start": 10001, "stop": 16145119}
         - {"contig": "chr2", "length": 16721010, "start": 16146120, "stop": 32867130}
-        - {"contig": "chr2", "length": 48494, "start": 32868131, "stop": 32916625}
+        - {"contig": "chr2", "length": 47170, "start": 32868131, "stop": 32915301}
       - - {"contig": "chr2", "length": 56413053, "start": 32917626, "stop": 89330679}
         - {"contig": "chr2", "length": 155312, "start": 89530680, "stop": 89685992}
         - {"contig": "chr2", "length": 648518, "start": 89753993, "stop": 90402511}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -103,8 +103,8 @@ constants:
       container: ghcr.io/tgen/containers/samtools_python:1.17-3.7.16-23082819
       digest: 2eaadfb976fd23f3583c5ab35c536349243cfd6e015002434735667c6bd62ead
     sigprofiler:
-      container: artifactory.tgen.org/hpc-virtual-containers/oci/testing/sigprofiler:0.0.24-24022900
-      digest: af719fe62393a4da95f723592d9519bd9ab011e52956d7b6c67fa2430050e76d
+      container: ghcr.io/tgen/containers/sigprofiler:0.0.24-24030411
+      digest: 4696efb66bdef231cbc64f145f777b847b47f6445444b30cd91713346f0c38ee
     snpsniffer:
       container: ghcr.io/tgen/containers/snpsniffer:7.0.0-23080810
       digest: 93831227364dbe82f42836844e34ee7d33d798885edb5b98f5aaf7f13f360eb5

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -103,8 +103,8 @@ constants:
       container: ghcr.io/tgen/containers/samtools_python:1.17-3.7.16-23082819
       digest: 2eaadfb976fd23f3583c5ab35c536349243cfd6e015002434735667c6bd62ead
     sigprofiler:
-      container: ghcr.io/tgen/containers/sigprofiler:0.0.24-23080710
-      digest: 42bcc6ed2d229cc39d39b476d2f76bec4b3a42a6cccf04c4ef18cd868496fa16
+      container: artifactory.tgen.org/hpc-virtual-containers/oci/testing/sigprofiler:0.0.24-24022900
+      digest: af719fe62393a4da95f723592d9519bd9ab011e52956d7b6c67fa2430050e76d
     snpsniffer:
       container: ghcr.io/tgen/containers/snpsniffer:7.0.0-23080810
       digest: 93831227364dbe82f42836844e34ee7d33d798885edb5b98f5aaf7f13f360eb5


### PR DESCRIPTION
This is adding some final fixes before we move forward with a 1.2.2 release:
* Disable running snpSniffer by default - this is for compatibility with naming schemes that do not match our internal naming scheme
* Removing a slight race condition for constitutional manta, where a two tasks could simultaneously be creating and deleting a directory
* Added prepare_tumor_only resets for the tumor only variant callers that were missing this directive
* Updated the sigprofilerAssignment container to avoid interruptions due to low signature input
* For tumorOnly sigprofiler we are now using our more heavily filtered/processed vcf as input
* Applying the same adjustments made in #64 to the `primary_contig_calling_intervals`, this is only used by octopus and the rna variant check workflow